### PR TITLE
Update rubies and bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ cache: bundler
 before_install: gem install bundler
 
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
   - ruby-head
 
 matrix:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,4 +25,4 @@ DEPENDENCIES
   rake (~> 13.0)
 
 BUNDLED WITH
-   1.17.2
+   2.3.0.dev


### PR DESCRIPTION
* Adds Ruby 3.0, 2.7, and 2.6
* Upgrades bundled with bundler
* Drop Ruby 2.2. It's EOL and won't build with new bundler on travis