### PR TITLE
Fix the copyright of Apache license

### DIFF
--- a/APACHE-LICENSE
+++ b/APACHE-LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2017 Tom Ward
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I fix the copyright of Apache license because it is not written correctly.