### PR TITLE
Prefer application/x-x509-ca-cert for .pem files

### DIFF
--- a/lib/marcel/mime_type/definitions.rb
+++ b/lib/marcel/mime_type/definitions.rb
@@ -32,6 +32,8 @@ Marcel::MimeType.extend "application/vnd.apple.keynote", extensions: %w( key ), 
 
 Marcel::MimeType.extend "image/vnd.dwg", magic: [[0, "AC10"]]
 
+Marcel::MimeType.extend "application/x-x509-ca-cert", magic: [[0, '-----BEGIN CERTIFICATE-----']], extensions: %w( pem ), parents: "application/x-x509-cert;format=pem"
+
 Marcel::MimeType.extend "image/heif", magic: [[4, "ftypmif1"]], extensions: %w( heif )
 Marcel::MimeType.extend "image/heic", magic: [[4, "ftypheic"]], extensions: %w( heic )
 

--- a/test/fixtures/magic/application/x-x509-ca-cert/x-x509-ca-cert.pem
+++ b/test/fixtures/magic/application/x-x509-ca-cert/x-x509-ca-cert.pem
@@ -1,0 +1,1 @@
+-----BEGIN CERTIFICATE-----

--- a/test/fixtures/name/application/x-x509-ca-cert/x-x509-ca-cert.pem
+++ b/test/fixtures/name/application/x-x509-ca-cert/x-x509-ca-cert.pem
@@ -1,0 +1,1 @@
+-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/42185

Previous to 1.0, marcel identified pem certs as `application/x-x509-ca-cert`. With the new mime source, it identifies pem files as `application/x-x509-cert;format=pem`.  This restores the previous behaviour by override similar to https://github.com/rails/marcel/commit/27fac74bd69663495410339bfd40ea8581ba669b.