### PR TITLE
Fix markdown file reporting to conform with IANA ->text/markdown

### DIFF
--- a/lib/marcel/mime_type/definitions.rb
+++ b/lib/marcel/mime_type/definitions.rb
@@ -60,3 +60,5 @@ Marcel::MimeType.extend(
   ],
   parents: "application/x-msaccess"
 )
+
+Marcel::MimeType.extend "text/markdown", extensions: %w(md mdtext markdown mkd), parents: "text/x-web-markdown"

--- a/test/fixtures/name/text/markdown/sample.markdown
+++ b/test/fixtures/name/text/markdown/sample.markdown
@@ -1,0 +1,1 @@
+# Hello World

--- a/test/fixtures/name/text/markdown/sample.md
+++ b/test/fixtures/name/text/markdown/sample.md
@@ -1,0 +1,1 @@
+# Hello World

--- a/test/fixtures/name/text/markdown/sample.mdtext
+++ b/test/fixtures/name/text/markdown/sample.mdtext
@@ -1,0 +1,1 @@
+# Hello World

--- a/test/fixtures/name/text/markdown/sample.mkd
+++ b/test/fixtures/name/text/markdown/sample.mkd
@@ -1,0 +1,1 @@
+# Hello World


### PR DESCRIPTION
Part of fix for https://github.com/rails/marcel/issues/48.

This fixes the markdown reporting for 
https://www.iana.org/assignments/media-types/media-types.xhtml

Previously MD files would be classified as `text/x-web-markdown`. This is restored to `text/markdown` as according to the v0.3.3 revision.


file | v0.3.3 type | a525d5b&nbsp;type
-- | -- | --
markdown.md | text/markdown | text/x-web-markdown
