### PR TITLE
Move to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        experimental: [false]
+        include:
+        - ruby: head
+          experimental: true
+        - ruby: jruby
+          experimental: true
+        - ruby: jruby-head
+          experimental: true
+        - ruby: truffleruby
+          experimental: true
+        - ruby: truffleruby-head
+          experimental: true
+
+    name: ${{ matrix.ruby }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake


### PR DESCRIPTION
Shall we move the CI over from buildkite to GitHub actions? Not even sure where the build kit runs are/or how to disable 🤷🏽‍♂️

Example of the actions running successfully -- https://github.com/hahmed/marcel/actions/runs/3766393607

Also it's weird that I marked jruby as allow failure, and the action passes. However there is a failure on the commit status and the action itself is successful. 