### PR TITLE
Update marcel to rack 3

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -z $1 ]]; then
+    bundle exec rake
+else
+    bundle exec rake TEST="$1"
+fi

--- a/lib/marcel/magic.rb
+++ b/lib/marcel/magic.rb
@@ -121,6 +121,10 @@ module Marcel
       io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
       buffer = "".encode(Encoding::BINARY)
 
+      unless io.respond_to?(:rewind)
+        io = StringIO.new(io.read)
+      end
+
       MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer) }
     end
 

--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rack', '~> 2.0'
+  spec.add_development_dependency 'rack', '~> 3.0'
   spec.add_development_dependency 'nokogiri', '>= 1.9.1'
   spec.add_development_dependency 'byebug', '~> 10.0.2'
 end

--- a/test/declared_type_test.rb
+++ b/test/declared_type_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'rack'
 
 class Marcel::MimeType::DeclaredTypeTest < Marcel::TestCase
   test "returns declared type as last resort" do

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'rack'
 
 class Marcel::MimeType::ExtensionTest < Marcel::TestCase
   test "ignores case and any preceding dot" do

--- a/test/magic_and_declared_type_test.rb
+++ b/test/magic_and_declared_type_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'rack'
 
 class Marcel::MimeType::MagicAndDeclaredTypeTest < Marcel::TestCase
   each_content_type_fixture('name') do |file, name, content_type|

--- a/test/mime_type_test.rb
+++ b/test/mime_type_test.rb
@@ -37,9 +37,9 @@ class Marcel::MimeTypeTest < Marcel::TestCase
     assert_equal "image/gif", content_type
   end
 
-  test "gets content type from sources that conform to Rack::Lint::InputWrapper" do
+  test "gets content type from sources that conform to Rack::Lint::Wrapper::InputWrapper" do
     io = StringIO.new(File.read(@path))
-    wrapper = Rack::Lint::InputWrapper.new(io)
+    wrapper = Rack::Lint::Wrapper::InputWrapper.new(io)
     content_type = Marcel::MimeType.for wrapper
     assert_equal "image/gif", content_type
   end


### PR DESCRIPTION
Update marcel to rack 3.

The InputWrapper is no longer rewindable (https://github.com/rack/rack/blob/a7d56490fd2fb41de8c94ead2f63fbad71c5c489/lib/rack/lint.rb#L405), so i wrapped the input into a new rewindable object but maybe it might be better to simply read the content only and improve the current logic to take that into consideration.

I also added a bin/test file to make it easier to test a specific file or run `bin/test` for all tests.