### PR TITLE
Fix Illustrator detection as application/pdf instead of application/illustrator

### DIFF
--- a/lib/marcel/mime_type.rb
+++ b/lib/marcel/mime_type.rb
@@ -27,14 +27,8 @@ module Marcel
       #
       # If no type can be determined, then +application/octet-stream+ is returned.
       def for(pathname_or_io = nil, name: nil, extension: nil, declared_type: nil)
-        type_from_data = for_data(pathname_or_io)
-        fallback_type = for_declared_type(declared_type) || for_name(name) || for_extension(extension) || BINARY
-
-        if type_from_data
-          most_specific_type type_from_data, fallback_type
-        else
-          fallback_type
-        end
+        filename_type = for_name(name) || for_extension(extension)
+        most_specific_type for_data(pathname_or_io), for_declared_type(declared_type), filename_type, BINARY
       end
 
       private
@@ -66,11 +60,7 @@ module Marcel
         end
 
         def for_declared_type(declared_type)
-          type = parse_media_type(declared_type)
-
-          if type != BINARY && !type.nil?
-            type.downcase
-          end
+          parse_media_type(declared_type)
         end
 
         def with_io(pathname_or_io, &block)
@@ -91,19 +81,9 @@ module Marcel
         # For some document types (notably Microsoft Office) we recognise the main content
         # type with magic, but not the specific subclass. In this situation, if we can get a more
         # specific class using either the name or declared_type, we should use that in preference
-        def most_specific_type(from_magic_type, fallback_type)
-          if (root_types(from_magic_type) & root_types(fallback_type)).any?
-            fallback_type
-          else
-            from_magic_type
-          end
-        end
-
-        def root_types(type)
-          if TYPE_EXTS[type].nil? || TYPE_PARENTS[type].nil?
-            [ type ]
-          else
-            TYPE_PARENTS[type].map {|t| root_types t }.flatten
+        def most_specific_type(*candidates)
+          candidates.compact.uniq.reduce do |type, candidate|
+            Marcel::Magic.child?(candidate, type) ? candidate : type
           end
         end
     end

--- a/test/illustrator_test.rb
+++ b/test/illustrator_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+require 'rack'
+
+class Marcel::MimeType::IllustratorTest < Marcel::TestCase
+  test ".ai uploaded as application/postscript" do
+    file = files("name/application/illustrator/illustrator.ai")
+    assert_equal "application/illustrator", Marcel::MimeType.for(file, name: "illustrator.ai", declared_type: "application/postscript")
+  end
+end


### PR DESCRIPTION
Given an .ai file with an application/postscript declared type, the filename extension would be ignored as a potential subtype of the application/pdf magic-byte-detected type.

Fix by evaluating all candidate types rather than a single fallback.