### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/marcel

### DIFF
--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 13.0'
   spec.add_development_dependency 'rack', '>= 2'
   spec.add_development_dependency 'nokogiri', '>= 1.9.1'
+
+  spec.metadata["changelog_uri"] = 'https://github.com/rails/marcel/releases'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/marcel which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/