### PR TITLE
Improve test_helper files method

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,7 @@ class Marcel::TestCase < Minitest::Test
   end
 
   def files(name)
-    Pathname.new fixture_path(name)
+    self.class.files(name)
   end
 
   def fixture_path(name)


### PR DESCRIPTION
The `files` instance method should micmic the `fixture_path` instance method behaviour (ie linking to class method).

This could avoid future issues with 2 `files` methods supposedly identical not giving the same output. 