### PR TITLE
Add support for .gpx files

### DIFF
--- a/data/custom.xml
+++ b/data/custom.xml
@@ -105,6 +105,15 @@
     </magic>
   </mime-type>
 
+  <mime-type type="application/gpx+xml">
+    <_comment>GPS Exchange Format (GPX)</_comment>
+    <sub-class-of type="application/xml" />
+    <glob pattern="*.gpx" />
+    <magic priority="50">
+      <match value="&lt;gpx" type="string" offset="0:4096" />
+    </magic>
+  </mime-type>
+
   <mime-type type="video/webm">
     <sub-class-of type="application/x-matroska" />
 

--- a/lib/marcel/tables.rb
+++ b/lib/marcel/tables.rb
@@ -401,6 +401,7 @@ module Marcel
     'gpg' => 'application/pgp-encrypted',
     'gph' => 'application/vnd.flographit',
     'gpkg' => 'application/x-geopackage',
+    'gpx' => 'application/gpx+xml',
     'gqf' => 'application/vnd.grafeq',
     'gqs' => 'application/vnd.grafeq',
     'gram' => 'application/srgs',
@@ -1330,6 +1331,7 @@ module Marcel
     'application/epub+zip' => %w(epub), # Electronic Publication
     'application/fits' => %w(fits fit fts), # Flexible Image Transport System
     'application/font-tdpfr' => %w(pfr),
+    'application/gpx+xml' => %w(gpx), # GPS Exchange Format (GPX)
     'application/gzip' => %w(gz tgz), # Gzip Compressed Archive
     'application/hwp+zip' => %w(hwpx), # Hangul Word Processor File, zip based
     'application/hyperstudio' => %w(stk),
@@ -2243,6 +2245,7 @@ module Marcel
     'application/dita+xml;format=map' => %w(application/dita+xml),
     'application/dita+xml;format=topic' => %w(application/dita+xml),
     'application/dita+xml;format=val' => %w(application/dita+xml),
+    'application/gpx+xml' => %w(application/xml),
     'application/hwp+zip' => %w(application/zip),
     'application/illustrator' => %w(application/pdf),
     'application/java-archive' => %w(application/zip),
@@ -2658,6 +2661,7 @@ module Marcel
     ['application/epub+zip', [[0, b["PK\003\004"], [[30, b['mimetypeapplication/epub+zip']]]]]],
     ['application/fits', [[0, b['SIMPLE  =                    T']], [0, b['SIMPLE  =                T']]]],
     ['application/java-vm', [[0, b["\312\376\272\276"]]]],
+    ['application/gpx+xml', [[0..4096, b['<gpx']]]],
     ['application/mac-binhex40', [[11, b['must be converted with BinHex']]]],
     ['application/marc', [[0, b['[0-9]{5,5}'], [[20, b['45'], [[5, b['[acdnp][acdefgijkmoprt][abcdims]']], [5, b['[acdnosx]z']], [5, b['[cdn][uvxy]']], [5, b['[acdn]w']], [5, b['[cdn]q']]]]]]]],
     ['application/mathematica', [[0, b['(**']], [0, b['(* ']]]],

--- a/test/fixtures/name/application/gpx+xml/gpx.gpx
+++ b/test/fixtures/name/application/gpx+xml/gpx.gpx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Wikipedia"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+  <!-- Comments look like this -->
+  <!-- Source: https://en.wikipedia.org/wiki/GPS_Exchange_Format -->
+  <metadata>
+    <name>Data name</name>
+    <desc>Valid GPX example without special characters</desc>
+    <author>
+      <name>Author name</name>
+    </author>
+  </metadata>
+  <wpt lat="52.518611" lon="13.376111">
+    <ele>35.0</ele>
+    <time>2011-12-31T23:59:59Z</time>
+    <name>Reichstag (Berlin)</name>
+    <sym>City</sym>
+  </wpt>
+  <wpt lat="48.208031" lon="16.358128">
+    <ele>179</ele>
+    <time>2011-12-31T23:59:59Z</time>
+    <name>Parlament (Wien)</name>
+    <sym>City</sym>
+  </wpt>
+  <wpt lat="46.9466" lon="7.44412">
+    <time>2011-12-31T23:59:59Z</time>
+    <name>Bundeshaus (Bern)</name>
+    <sym>City</sym>
+  < /wpt>
+</gpx>


### PR DESCRIPTION
Adds support for [GPS Exchange Format](https://en.wikipedia.org/wiki/GPS_Exchange_Format) (GPX).

**Context**  
The uploaded GPX files to my app were identified as `application/xml` and failed the content type validation.


ps: Let me know if I missed something ;) 