### PR TITLE
improve HTML detection

### DIFF
--- a/lib/marcel/mime_type/definitions.rb
+++ b/lib/marcel/mime_type/definitions.rb
@@ -1,7 +1,28 @@
 # frozen_string_literal: true
 
 Marcel::MimeType.extend "text/plain", extensions: %w( txt asc )
-Marcel::MimeType.extend "text/html", magic: [[0..64, "<!DOCTYPE HTML"], [0..64, "<!DOCTYPE html"], [0..64, "<!doctype HTML"], [0..64, "<!doctype html"]]
+
+Marcel::Magic.remove("text/html")
+Marcel::MimeType.extend "text/html", 
+  extensions: %w( html htm ),
+  magic: [
+    [0, "<!DOCTYPE html"],
+    [0, "<!DOCTYPE HTML"], 
+    [0, "<!doctype html"],
+    [0, "<!doctype HTML"],
+    [0, "<html"],
+    [0, "<HTML"],
+    [0, " <!DOCTYPE html"],
+    [0, "\n<!DOCTYPE html"],
+    [0, "\r<!DOCTYPE html"], 
+    [0, "\r\n<!DOCTYPE html"],
+    [0, "\t<!DOCTYPE html"],
+    [0, " <html"],
+    [0, "\n<html"],
+    [0, "\r<html"],
+    [0, "\r\n<html"],
+    [0, "\t<html"]
+  ]
 
 Marcel::MimeType.extend "application/illustrator", parents: "application/pdf"
 Marcel::MimeType.extend "image/vnd.adobe.photoshop", magic: [[0, "8BPS"]], extensions: %w( psd psb )

--- a/test/fixtures/name/application/json/json.json
+++ b/test/fixtures/name/application/json/json.json
@@ -1,3 +1,4 @@
 {
-  "name": "JSON"
+  "name": "JSON",
+  "tag": "<html></html>"
 }

--- a/test/fixtures/name/text/csv/csv.csv
+++ b/test/fixtures/name/text/csv/csv.csv
@@ -1,2 +1,2 @@
-Name,Age,Occupation
-Marcel Marceau,94,Mime
+Name,Age,Occupation,Quote
+Marcel Marceau,94,Mime,I used to develop in <html> a lot but now it's just some <body> that I used to know


### PR DESCRIPTION
Hi folks, :wave: 

anything, that contained a starting HTML tag (`<html`) in the first characters was identified as an HTML. This patch should make the detection a little more robust. 🤞

See issue #79 for more details


**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a PO/PM or Ruby/Rails/Crystal dev