### PR TITLE
add fixture for BOM CSV

### DIFF
--- a/test/fixtures/name/text/csv/bom.csv
+++ b/test/fixtures/name/text/csv/bom.csv
@@ -1,0 +1,2 @@
+﻿Name,Age,Occupation
+Marcel Marceau,94,Mime


### PR DESCRIPTION
Hi folks,

I think that issue #103 might've been fixed at one point?

At least everything still works with the attached fixture.
It might look the same on GitHub but you can double check with `hexdump -C test/fixtures/name/text/csv/bom.csv`.

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a PO/PM or Ruby/Rails/Crystal dev