### PR TITLE
Fix Ruby 3.4 frozen string literal warnings with StringIO

### DIFF
--- a/lib/marcel/magic.rb
+++ b/lib/marcel/magic.rb
@@ -115,7 +115,11 @@ module Marcel
     end
 
     def self.magic_match(io, method)
-      return magic_match(StringIO.new(io.to_s), method) unless io.respond_to?(:read)
+      return magic_match(StringIO.new(+io.to_s), method) unless io.respond_to?(:read)
+
+      # Make StringIO readonly before encoding changes to prevent Ruby 3.4 frozen string warnings.
+      # Should be fixed in Ruby 3.5+: https://redmine.ruby-lang.org/issues/21280
+      io.close_write if io.respond_to?(:closed_write?) && !io.closed_write?
 
       io.binmode if io.respond_to?(:binmode)
       io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)

--- a/test/magic_test.rb
+++ b/test/magic_test.rb
@@ -25,4 +25,25 @@ class Marcel::MimeType::MagicTest < Marcel::TestCase
     assert Marcel::Magic.child?('text/csv', 'text/plain')
     refute Marcel::Magic.child?('text/plain', 'text/csv')
   end
+
+  test "no Ruby 3.4 frozen string warnings with StringIO" do
+    # Ruby 3.4 warns about code that will break when frozen string literals become default
+    # This test ensures marcel handles StringIO with frozen strings correctly
+    content = "Test content for mime detection"
+    io = StringIO.new(content)
+
+    # Capture warnings
+    warnings = []
+    original_stderr = $stderr
+    $stderr = StringIO.new
+
+    begin
+      Marcel::MimeType.for(io)
+      warnings = $stderr.string.lines.grep(/marcel.*magic\.rb.*frozen/)
+    ensure
+      $stderr = original_stderr
+    end
+
+    assert_empty warnings, "Expected no frozen string warnings, but got:\n#{warnings.join}"
+  end
 end


### PR DESCRIPTION
Fixes #139

### Problem

PR #123 fixed frozen string warnings on line 127, but missed warnings triggered by calling `binmode` and `set_encoding` on StringIO objects. Rails applications running tests with verbose warnings (`-W2`) see this warning repeatedly:

```
/gems/marcel-1.1.0/lib/marcel/magic.rb:120: warning: literal string will be frozen in the future
```

### Solution

Make StringIO readonly before encoding modifications to prevent the warning:

```ruby
# Make StringIO readonly before encoding changes to prevent Ruby 3.4 frozen string warnings.
# Should be fixed in Ruby 3.5+: https://redmine.ruby-lang.org/issues/21280
io.close_write if io.respond_to?(:closed_write?) && !io.closed_write?

io.binmode if io.respond_to?(:binmode)
io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
```

**How it works:**
- StringIO objects have a `closed_write?` method that File objects don't
- Calling `close_write` makes the StringIO readonly, preventing internal string modifications
- This prevents the frozen string warning when `binmode`/`set_encoding` are subsequently called
- File objects don't have `closed_write?`, so they're unaffected

**Why this approach:**
- Uses `respond_to?` pattern consistently with existing code
- still calls `binmode` and `set_encoding` as originally intended
- Proactively checks writability before calling (no `rescue` needed)
- Only affects StringIO, which is the only IO type that triggers these warnings

### Testing

Added a test that captures stderr and verifies no frozen string warnings when processing StringIO objects. All 384 existing tests pass. The test provides a runnable example that demonstrates the fix works correctly.

### Future

This workaround should only be needed until Ruby 3.5, which will include an upstream fix that prevents false-positive warnings on StringIO encoding operations: https://redmine.ruby-lang.org/issues/21280