### PR TITLE
Stop mutating source IO state during magic-byte detection

### DIFF
--- a/lib/marcel/magic.rb
+++ b/lib/marcel/magic.rb
@@ -115,11 +115,7 @@ module Marcel
     end
 
     def self.magic_match(io, method)
-      return magic_match(StringIO.new(+io.to_s), method) unless io.respond_to?(:read)
-
-      # Make StringIO readonly before encoding changes to prevent Ruby 3.4 frozen string warnings.
-      # Should be fixed in Ruby 3.5+: https://redmine.ruby-lang.org/issues/21280
-      io.close_write if io.respond_to?(:closed_write?) && !io.closed_write?
+      return magic_match(StringIO.new(io.to_s), method) unless io.respond_to?(:read)
 
       buffer = (+"").encode(Encoding::BINARY)
 

--- a/lib/marcel/magic.rb
+++ b/lib/marcel/magic.rb
@@ -121,8 +121,6 @@ module Marcel
       # Should be fixed in Ruby 3.5+: https://redmine.ruby-lang.org/issues/21280
       io.close_write if io.respond_to?(:closed_write?) && !io.closed_write?
 
-      io.binmode if io.respond_to?(:binmode)
-      io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
       buffer = (+"").encode(Encoding::BINARY)
 
       MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer) }

--- a/test/mime_type_test.rb
+++ b/test/mime_type_test.rb
@@ -53,4 +53,13 @@ class Marcel::MimeTypeTest < Marcel::TestCase
       assert_equal "image/gif", content_type
     end
   end
+
+  test "does not mutate the source IO's encoding" do
+    io = StringIO.new("hello world")
+    original_encoding = io.external_encoding
+
+    Marcel::MimeType.for(io)
+
+    assert_equal original_encoding, io.external_encoding
+  end
 end


### PR DESCRIPTION
# Stop mutating source IO state during magic-byte detection

### Problem

`Marcel::MimeType.for(io)` permanently mutates the source IO's encoding. Callers that read the IO after mime detection get back ASCII-8BIT bytes regardless of how they originally opened it:

```ruby
require "stringio"
io = StringIO.new("hello world")
io.external_encoding   # => #<Encoding:UTF-8>
Marcel::MimeType.for(io)
io.external_encoding   # => #<Encoding:BINARY (ASCII-8BIT)>
```

For StringIO objects the underlying string is also re-tagged in place. When the bytes are then JSON-encoded, this trips the json gem's `UTF-8 string passed as BINARY` warning, which becomes an error in json 3.0.

### Cause

`magic_match` calls `io.binmode` and `io.set_encoding(Encoding::BINARY)` before reading magic bytes:

```ruby
io.binmode if io.respond_to?(:binmode)
io.set_encoding(Encoding::BINARY) if io.respond_to?(:set_encoding)
buffer = (+"").encode(Encoding::BINARY)

MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer) }
```

These two lines were carried over from mimemagic in #30 and predate the `buffer` parameter pattern in `magic_match_io`. They're redundant - `magic_match_io` reads via `IO#read(n, buffer)` with a binary-encoded buffer, which already produces a binary result regardless of the IO's mode.

### Solution

This PR has two commits.

**Commit 1: remove the redundant mutations.** `binmode` and `set_encoding(Encoding::BINARY)` are gone. `magic_match_io` reads through the binary buffer.

**Commit 2: remove the workarounds those mutations required.** With the mutations gone, the support code added to keep them safe under Ruby 3.4 is no longer needed:

- `+io.to_s` (the mutable-string fallback, #140) - only needed because `set_encoding` would later try to mutate the StringIO's underlying string. With no `set_encoding` call, a frozen string is fine.
- `io.close_write` (#140) - only needed to make the StringIO read-only before `binmode`/`set_encoding` so Ruby 3.4 wouldn't warn about modifying the underlying frozen string. With no encoding modification, there's nothing to warn about.

The "no Ruby 3.4 frozen string warnings with StringIO" regression test from #140 still passes.

### Test

Adds a regression test asserting `external_encoding` survives a call to `Marcel::MimeType.for`:

```ruby
test "does not mutate the source IO's encoding" do
  io = StringIO.new("hello world")
  original_encoding = io.external_encoding

  Marcel::MimeType.for(io)

  assert_equal original_encoding, io.external_encoding
end
```
