### PR TITLE
Detect HTML in partial reads

### DIFF
--- a/lib/marcel/mime_type/definitions.rb
+++ b/lib/marcel/mime_type/definitions.rb
@@ -6,7 +6,7 @@ Marcel::Magic.remove("text/html")
 Marcel::MimeType.extend "text/html", 
   extensions: %w( html htm ),
   magic: [
-    [64, %r{\A\s*<(!DOCTYPE html|html)}mi],
+    [0, %r{\A(?:\xEF\xBB\xBF)?\s*(?:<\?xml\s+[^>]*\?>\s*)?(?:<!--.*?-->\s*)*<(?:!DOCTYPE\s+html|html)(?=[\s>])}min],
     [-64, %r{</html>\s*\z}mi],
   ]
 

--- a/test/magic_test.rb
+++ b/test/magic_test.rb
@@ -12,6 +12,29 @@ class Marcel::MimeType::MagicTest < Marcel::TestCase
     end
   end
 
+  test "detects HTML in partial reads with leading metadata" do
+    prefixes = [
+      "<!-- leading comment, padded past 128 characters: #{"a" * 90} -->\n",
+      "\xEF\xBB\xBF".b,
+      "<?xml version=\"1.0\"?>\n"
+    ]
+
+    prefixes.each do |prefix|
+      html = prefix + "<html><body>\n" + ("<p>x</p>\n" * 600) + "</body></html>"
+      chunk = html.byteslice(0, 4096)
+
+      assert_equal 4096, chunk.bytesize
+      refute_includes chunk, "</html>"
+      assert_equal "text/html", Marcel::MimeType.for(
+        StringIO.new(chunk), name: "page.html", declared_type: "text/html"
+      )
+    end
+  end
+
+  test "does not detect an HTML-prefixed custom element as HTML" do
+    assert_equal "application/octet-stream", Marcel::MimeType.for(StringIO.new("<html-custom>"))
+  end
+
   test "add and remove type" do
     Marcel::Magic.add('application/x-my-thing', extensions: 'mtg', parents: 'application/json')
     Marcel::Magic.remove('application/x-my-thing')


### PR DESCRIPTION
## Summary

- detect HTML in leading-byte reads when a UTF-8 BOM, XML declaration, or HTML comments precede the doctype or `html` element
- keep the trailing `</html>` signal and require a real tag-name boundary
- cover the 4 KiB partial-read shape used by Active Storage, including a custom-element negative boundary

This removes the dependency on seeing the end of a document when only its first bytes are available.

Fixes #152.

## Validation

- `bundle exec ruby -Itest test/magic_test.rb -n '/partial|custom/'` (2 tests, 13 assertions)
- `bundle exec rake` (454 tests, 934 assertions)
- `ruby -c lib/marcel/mime_type/definitions.rb`
- `ruby -c test/magic_test.rb`
- `gem build marcel.gemspec`
- `git diff --check`
