### PR TITLE
Validate MIME data before generating tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Marcel was extracted from Basecamp's file detection heuristics. The aim is provi
 
 ## Contributing
 
-Marcel generates MIME lookup tables with `bundle exec rake update`. MIME types are seeded from data found in `data/*.xml`. Custom MIMEs may be added to `data/custom.xml`, while overrides to the standard MIME database may be added to `lib/marcel/mime_type/definitions.rb`.
+Marcel generates MIME lookup tables with `bundle exec rake update`. MIME types are seeded from data found in `data/*.xml`. The Apache Tika download and committed `data/tika.xml` are verified against the commit and checksum in `script/download_tika_data.rb`; review and update both values when refreshing it. Custom MIMEs may be added to `data/custom.xml`, while overrides to the standard MIME database may be added to `lib/marcel/mime_type/definitions.rb`.
 
 Marcel follows the same contributing guidelines as [rails/rails](https://github.com/rails/rails#contributing).
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require 'bundler/gem_tasks'
+require 'fileutils'
 require 'rake/testtask'
+require 'rbconfig'
+require 'tempfile'
 
-task default: :test
+task default: [ :test, "tables:check" ]
 
 Rake::TestTask.new :test do |t|
   t.libs << "test"
@@ -38,17 +41,53 @@ task :types do
   end
 end
 
-desc "Download latest Tika data and update data tables"
+desc "Download pinned Tika data and update data tables"
 task update: [ "tika:download", "tables" ]
 
 desc "Generate data tables"
 task :tables do
-  sh "script/generate_tables.rb", "data/tika.xml", "data/custom.xml", out: "lib/marcel/tables.rb"
+  atomically_replace "lib/marcel/tables.rb" do |temporary_path|
+    generate_tables temporary_path
+  end
+end
+
+namespace :tables do
+  desc "Verify that committed data tables match their XML sources"
+  task :check do
+    Tempfile.create([ "marcel-tables", ".rb" ]) do |temporary|
+      temporary.close
+      generate_tables temporary.path
+
+      unless FileUtils.compare_file(temporary.path, "lib/marcel/tables.rb")
+        abort "lib/marcel/tables.rb is stale; run `bundle exec rake tables`"
+      end
+    end
+  end
 end
 
 namespace :tika do
-  desc "Download latest data/tika.xml"
+  desc "Download pinned data/tika.xml"
   task :download do
-    sh "script/download_tika_data.rb", out: "data/tika.xml"
+    atomically_replace "data/tika.xml" do |temporary_path|
+      sh "script/download_tika_data.rb", out: temporary_path
+    end
   end
+end
+
+def atomically_replace(destination)
+  mode = File.exist?(destination) ? File.stat(destination).mode & 0o777 : 0o644
+
+  Tempfile.create([ File.basename(destination), ".tmp" ], File.dirname(destination)) do |temporary|
+    temporary_path = temporary.path
+    temporary.close
+    yield temporary_path
+    File.chmod(mode, temporary_path)
+    File.rename(temporary_path, destination)
+  end
+end
+
+def generate_tables(destination)
+  sh "script/download_tika_data.rb", "--verify", "data/tika.xml"
+  sh "script/generate_tables.rb", "--output", destination, "data/tika.xml", "data/custom.xml"
+  sh RbConfig.ruby, "-c", destination
 end

--- a/data/custom.xml
+++ b/data/custom.xml
@@ -178,4 +178,12 @@
 
     <sub-class-of type="text/plain"/>
   </mime-type>
+
+  <!-- Tika declares text/x-c as an alias of text/x-csrc, but Marcel's tables do not
+       otherwise model aliases. Keep the X bitmap parent graph on canonical types. -->
+  <mime-type type="image/x-xbitmap">
+    <glob pattern="*.xbm" />
+
+    <sub-class-of type="text/x-csrc"/>
+  </mime-type>
 </mime-info>

--- a/data/tika.xml
+++ b/data/tika.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Downloaded at 2026-05-19 17:29:02 UTC from https://raw.githubusercontent.com/apache/tika/main/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml -->
+<!-- Downloaded from https://raw.githubusercontent.com/apache/tika/c29724782854bb5a319f4a1940d0828a58ace3f9/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml -->
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/lib/marcel/tables.rb
+++ b/lib/marcel/tables.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This file is auto-generated. Instead of editing this file, please
-# add MIMEs to data/custom.xml or lib/marcel/mime_type/definitions.rb.
+# add MIMEs to data/custom.xml or the definitions files under lib/marcel.
 
 module Marcel
   # @private
@@ -441,7 +441,7 @@ module Marcel
     'hpgl' => 'application/vnd.hp-hpgl',
     'hpid' => 'application/vnd.hp-hpid',
     'hpp' => 'text/x-c++hdr',
-    'hprof' => 'application/vnd.java.hprof ',
+    'hprof' => 'application/vnd.java.hprof',
     'hprof.txt' => 'application/vnd.java.hprof.text',
     'hps' => 'application/vnd.hp-hps',
     'hqx' => 'application/mac-binhex40',
@@ -2410,7 +2410,7 @@ module Marcel
     'image/x-portable-bitmap' => %w(image/x-portable-anymap),
     'image/x-portable-graymap' => %w(image/x-portable-anymap),
     'image/x-portable-pixmap' => %w(image/x-portable-anymap),
-    'image/x-xbitmap' => %w(text/x-c),
+    'image/x-xbitmap' => %w(text/x-csrc),
     'message/rfc822' => %w(text/x-tika-text-based-message),
     'message/x-emlx' => %w(text/x-tika-text-based-message),
     'model/vnd.dwfx+xps' => %w(application/x-tika-ooxml),
@@ -2521,7 +2521,7 @@ module Marcel
     ['image/bmp', [[0, b['BM'], [[26, b["\001\000"], [[0, nil, [[0, nil, [[28, b["\000\000"]], [28, b["\001\000"]], [28, b["\004\000"]], [28, b["\b\000"]], [28, b["\020\000"]], [28, b["\030\000"]], [28, b[" \000"]]]], [30, b["\000\000\000\000"]]]]]]]]]],
     ['image/vnd.adobe.photoshop', [[0, b["8BPS\000\001"]], [0, b["8BPS\000\002"]]]],
     ['image/webp', [[0, b['RIFF'], [[8, b['WEBP']]]]]],
-    ['text/html', [[0, /(?i)<(html|head|body|title|div)[ >]/], [0, /(?i)<h[123][ >]/]]],
+    ['text/html', [[0, Regexp.new("(?i)<(html|head|body|title|div)[ >]".b, 0).freeze], [0, Regexp.new("(?i)<h[123][ >]".b, 0).freeze]]],
     ['image/svg+xml', [[0, b['<svg']]]],
     ['video/x-msvideo', [[0, b['RIFF'], [[8, b['AVI ']]]], [8, b['AVI ']]]],
     ['video/x-ms-wmv', [[0..8192, b["W\000i\000n\000d\000o\000w\000s\000 \000M\000e\000d\000i\000a\000 \000V\000i\000d\000e\000o\000"]], [0..8192, b["V\000C\000-\0001\000 \000A\000d\000v\000a\000n\000c\000e\000d\000 \000P\000r\000o\000f\000i\000l\000e\000"]], [0..8192, b["w\000m\000v\0002\000"]]]],
@@ -2534,7 +2534,7 @@ module Marcel
     ['video/x-flv', [[0, b['FLV']]]],
     ['audio/mpeg', [[0, b["\377\362"]], [0, b["\377\363"]], [0, b["\377\364"]], [0, b["\377\365"]], [0, b["\377\366"]], [0, b["\377\367"]], [0, b["\377\372"]], [0, b["\377\373"]], [0, b["\377\374"]], [0, b["\377\375"]], [0, b["\377\343"]], [0, b['ID3']]]],
     ['application/pdf', [[0, b['%PDF-']], [0, b["\357\273\277%PDF-"]]]],
-    ['application/msword', [[0..8, b["\320\317\021\340\241\261\032\341"], [[546, b['jbjb']], [546, b['bjbj']]]]]],
+    ['application/msword', [[2080, b['Microsoft Word 6.0 Document']], [2080, b['Documento Microsoft Word 6']], [2112, b['MSWordDoc']], [0, b["1\276\000\000"]], [0, b['PO^Q`']], [0, b["\3767\000#"]], [0, b["\333\245-\000\000\000"]], [0, b["\224\246."]], [0..8, b["\320\317\021\340\241\261\032\341"], [[1152..4096, b["W\000o\000r\000d\000D\000o\000c\000u\000m\000e\000n\000t"]]]]]],
     ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0, b["PK\003\004"], [[30..65536, b['[Content_Types].xml'], [[0..4096, b['word/']]]], [30, b['_rels/.rels'], [[0..4096, b['word/']]]]]]]],
     ['application/vnd.ms-powerpoint', [[0..8, b["\320\317\021\340\241\261\032\341"], [[1152..4096, b["P\000o\000w\000e\000r\000P\000o\000i\000n\000t\000 D\000o\000c\000u\000m\000e\000n\000t"]]]]]],
     ['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0, b["PK\003\004"], [[30..65536, b['[Content_Types].xml'], [[0..4096, b['ppt/']]]], [30, b['_rels/.rels'], [[0..4096, b['ppt/']]]]]]]],
@@ -2661,7 +2661,7 @@ module Marcel
     ['application/java-vm', [[0, b["\312\376\272\276"]]]],
     ['application/mac-binhex40', [[11, b['must be converted with BinHex']]]],
     ['application/mathematica', [[0, b['(**']], [0, b['(* ']]]],
-    ['application/msword', [[2080, b['Microsoft Word 6.0 Document']], [2080, b['Documento Microsoft Word 6']], [2112, b['MSWordDoc']], [0, b["1\276\000\000"]], [0, b['PO^Q`']], [0, b["\3767\000#"]], [0, b["\333\245-\000\000\000"]], [0, b["\224\246."]], [0..8, b["\320\317\021\340\241\261\032\341"], [[1152..4096, b["W\000o\000r\000d\000D\000o\000c\000u\000m\000e\000n\000t"]]]]]],
+    ['application/msword', [[0..8, b["\320\317\021\340\241\261\032\341"], [[546, b['jbjb']], [546, b['bjbj']]]]]],
     ['application/msword2', [[0, b["\233\245"]], [0, b["\333\245"]]]],
     ['application/msword5', [[0, b["\3767"]]]],
     ['application/octet-stream', [[10, b['# This is a shell archive']], [0, b["\037\036"]], [0, b["\037\037"]], [0, b["\377\037"]], [0, b["\377\037"]], [0, b["\005\313"]]]],
@@ -2680,8 +2680,8 @@ module Marcel
     ['application/vnd.digilite.prolights', [[0, b["\177\fD+"]]]],
     ['application/vnd.fdf', [[0, b['%FDF-']]]],
     ['application/vnd.iccprofile', [[36, b['acsp']]]],
-    ['application/vnd.java.hprof', [[0, /JAVA PROFILE \d\.\d\.\d\u0000/]]],
-    ['application/vnd.java.hprof.text', [[0, /JAVA PROFILE \d\.\d\.\d,/]]],
+    ['application/vnd.java.hprof', [[0, Regexp.new("JAVA PROFILE \\d\\.\\d\\.\\d\\u0000".b, 0).freeze]]],
+    ['application/vnd.java.hprof.text', [[0, Regexp.new("JAVA PROFILE \\d\\.\\d\\.\\d,".b, 0).freeze]]],
     ['application/vnd.lotus-1-2-3;version=1', [[0, b["\000\000\002\000\004\004"]]]],
     ['application/vnd.lotus-1-2-3;version=2', [[0, b["\000\000\002\000\006\004\006\000\b\000"]]]],
     ['application/vnd.lotus-1-2-3;version=3', [[0, b["\000\000\032\000\000\020\004\000"]]]],
@@ -2754,7 +2754,7 @@ module Marcel
     ['application/x-endnote-style', [[0, b["\000\b"], [[4, b["\000\000"], [[8, b['RSFTSTYL']], [8, b['ENDNENFT']]]]]]]],
     ['application/x-erdas-hfa', [[0, b['EHFA_HEADER_TAG']]]],
     ['application/x-executable', [[0, b["\177ELF"], [[16, b["\002\000"]], [16, b["\000\002"]]]]]],
-    ['application/x-fat-diskimage', [[0, b["\\353"], [[2, b["\\220"]]]]]],
+    ['application/x-fat-diskimage', [[0, b["\\xEB"], [[2, b["\\x90"]]]]]],
     ['application/x-filemaker', [[14, b["\300HBAM7"], [[525, b["HBAM2101OCT99\301\002H\aPro 7.0\300\300"]]]]]],
     ['application/x-foxmail', [[0, b["\020\020\020\020\020\020\020\021\021\021\021\021\021S"]]]],
     ['application/x-gnumeric', [[39, b['=<gmr:Workbook']]]],
@@ -2910,7 +2910,7 @@ module Marcel
     ['application/pdf', [[0..128, b['%%'], [[1..512, b['%PDF-1.']]]], [0..128, b['%%'], [[1..512, b['%PDF-2.']]]]]],
     ['application/vnd.wordperfect', [[0, b["\377WPC"]]]],
     ['application/x-bzip', [[0, b['BZ0']]]],
-    ['application/x-bzip2', [[0, /BZh[1-9]/]]],
+    ['application/x-bzip2', [[0, Regexp.new("BZh[1-9]".b, 0).freeze]]],
     ['application/x-font-adobe-metric', [[0, b['StartFontMetrics']]]],
     ['application/x-font-otf', [[0, b["OTTO\000"]]]],
     ['application/x-font-printer-metric', [[0, b["\000\001"], [[4, b["\000\000Copyr"]]]]]],

--- a/script/download_tika_data.rb
+++ b/script/download_tika_data.rb
@@ -1,11 +1,49 @@
 #!/usr/bin/env ruby
+require 'digest'
 require 'net/http'
 require 'uri'
 
-url = URI("https://raw.githubusercontent.com/apache/tika/main/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml")
+# To update the MIME database, review a new Tika commit and update both values.
+TIKA_COMMIT = "c29724782854bb5a319f4a1940d0828a58ace3f9".freeze
+TIKA_DATA_SHA256 = "b213c35123f215e11a9fa12d7907c9bb0a5b79214a89eeaf343984ba69143e6d".freeze
+TIKA_URL = "https://raw.githubusercontent.com/apache/tika/#{TIKA_COMMIT}/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml".freeze
+TIKA_PROVENANCE = "<!-- Downloaded from #{TIKA_URL} -->\n".freeze
+TIKA_PREAMBLE = /\A(?:<\?xml[^\n]*\?>\n)?/.freeze
+
+def verify_tika_data(data, source)
+  checksum = Digest::SHA256.hexdigest(data)
+  return if checksum == TIKA_DATA_SHA256
+
+  abort "Unexpected Tika MIME data checksum for #{source}: #{checksum}"
+end
+
+def annotate_tika_data(data)
+  offset = TIKA_PREAMBLE.match(data).end(0)
+  data.dup.insert(offset, TIKA_PROVENANCE)
+end
+
+def verify_annotated_tika_data(data, source)
+  offset = TIKA_PREAMBLE.match(data).end(0)
+  unless data.byteslice(offset, TIKA_PROVENANCE.bytesize) == TIKA_PROVENANCE
+    abort "Unexpected Tika provenance comment in #{source}"
+  end
+
+  upstream_data = data.dup
+  upstream_data.slice!(offset, TIKA_PROVENANCE.bytesize)
+  verify_tika_data(upstream_data, source)
+end
+
+if ARGV.first == "--verify"
+  abort "Usage: #{$0} --verify path/to/tika.xml" unless ARGV.length == 2
+
+  verify_annotated_tika_data(File.binread(ARGV.last), ARGV.last)
+  exit
+elsif ARGV.any?
+  abort "Usage: #{$0} [--verify path/to/tika.xml]"
+end
+
+url = URI(TIKA_URL)
 data = Net::HTTP.get_response(url).tap(&:value).body
+verify_tika_data(data, url)
 
-# Insert a comment indicating provenance
-data.sub! /\A(?:<\?xml.+\?>\n)?/, "\\&<!-- Downloaded at #{Time.now.utc} from #{url} -->\n"
-
-puts data
+puts annotate_tika_data(data)

--- a/script/generate_tables.rb
+++ b/script/generate_tables.rb
@@ -4,6 +4,12 @@
 # Copyright (c) 2011 Daniel Mendler. Available at https://github.com/mimemagicrb/mimemagic.
 
 require 'nokogiri'
+require 'digest'
+require 'open3'
+require 'optparse'
+require 'rbconfig'
+require 'stringio'
+require 'tempfile'
 
 module TikaRegex
   # Apache Tika uses Java regex syntax, which has some differences from Ruby:
@@ -52,16 +58,140 @@ module TikaRegex
   end
 end
 
-class String
-  alias inspect_old inspect
-
-  def inspect
-    str = b.inspect_old.gsub(/\\x([0-9a-f]{2})/i) do
-      '\\%03o' % $1.to_i(16)
+module RubySource
+  def self.string(value)
+    source = value.b.dump.gsub(/(\\+)x([0-9a-f]{2})/i) do |escape|
+      slashes = $1
+      if slashes.length.odd?
+        slashes[0...-1] + ('\\%03o' % $2.to_i(16))
+      else
+        escape
+      end
     end
-    str.gsub!('"', '\'') unless str.match?(/[\\']/)
-    str
+    source.tr!('"', '\'') unless source.match?(/[\\']/)
+    source
   end
+
+  def self.words(values)
+    if values.all? { |value| safe_word?(value) }
+      "%w(#{values.join(' ')})"
+    else
+      "[#{values.map { |value| string(value) }.join(', ')}]"
+    end
+  end
+
+  def self.comment(value)
+    value.gsub(/[\x00-\x1f\x7f]|\u0085|\u2028|\u2029/, " ")
+  end
+
+  def self.safe_word?(value)
+    !value.empty? && value.each_byte.all? do |byte|
+      byte > 0x20 && byte < 0x7f && byte != 0x28 && byte != 0x29 && byte != 0x5c
+    end
+  end
+end
+
+module MimeData
+  TOKEN = "[!#$%&'*+\\-.^_`|~0-9A-Za-z]+".freeze
+  TYPE = %r{\A#{TOKEN}/#{TOKEN}(?:;[ \t]*#{TOKEN}=#{TOKEN})*\z}.freeze
+  EXTENSION = /\A[0-9A-Za-z][0-9A-Za-z.+_~-]*\z/.freeze
+  OFFSET = /\A\d+(?::\d+)?\z/.freeze
+  PRIORITY = /\A\d+\z/.freeze
+  MAX_MAGIC_OFFSET = 64 * 1024
+  MAX_MAGIC_RANGE_BYTES = 64 * 1024
+  MAX_MAGIC_PRIORITY = 100
+
+  def self.type(value, source)
+    if value&.match?(/[\x00-\x08\x0A-\x1F\x7F]/)
+      raise ArgumentError, "Invalid MIME type in #{source}: #{value.inspect}"
+    end
+
+    normalized = value&.strip
+    unless normalized&.match?(TYPE)
+      raise ArgumentError, "Invalid MIME type in #{source}: #{value.inspect}"
+    end
+
+    normalized
+  end
+
+  def self.extension(value, source)
+    unless value&.match?(EXTENSION)
+      raise ArgumentError, "Invalid extension in #{source}: #{value.inspect}"
+    end
+
+    value.downcase
+  end
+
+  def self.offset(value, source)
+    maximum_length = "#{MAX_MAGIC_OFFSET}:#{MAX_MAGIC_OFFSET}".bytesize
+    unless value && value.bytesize <= maximum_length && value.match?(OFFSET)
+      raise ArgumentError, "Invalid magic offset in #{source}: #{value.inspect}"
+    end
+
+    bounds = value.split(":").map { |bound| Integer(bound, 10) }
+    if bounds.any? { |bound| bound > MAX_MAGIC_OFFSET }
+      raise ArgumentError, "Magic offset exceeds #{MAX_MAGIC_OFFSET} in #{source}: #{value.inspect}"
+    end
+    if bounds.size == 2 && bounds.first > bounds.last
+      raise ArgumentError, "Descending magic offset in #{source}: #{value.inspect}"
+    end
+    if bounds.size == 2 && bounds.last - bounds.first + 1 > MAX_MAGIC_RANGE_BYTES
+      raise ArgumentError, "Magic range exceeds #{MAX_MAGIC_RANGE_BYTES} bytes in #{source}: #{value.inspect}"
+    end
+
+    bounds.size == 2 ? bounds[0]..bounds[1] : bounds[0]
+  end
+
+  def self.priority(value, source)
+    unless value && value.bytesize <= MAX_MAGIC_PRIORITY.to_s.bytesize && value.match?(PRIORITY)
+      raise ArgumentError, "Invalid magic priority in #{source}: #{value.inspect}"
+    end
+
+    priority = Integer(value, 10)
+    if priority > MAX_MAGIC_PRIORITY
+      raise ArgumentError, "Magic priority exceeds #{MAX_MAGIC_PRIORITY} in #{source}: #{value.inspect}"
+    end
+
+    priority
+  end
+end
+
+class UnsupportedRules
+  # Tika currently contains 58 unsupported XML rules. Their pretty-printed warnings
+  # span 112 physical lines, so pin the canonical rule set rather than stderr layout.
+  EXPECTED_COUNT = 58
+  EXPECTED_SHA256 = "15d595d20bca116234fda6893b8fceb1533fcbd542d425a6d609d2efcb51b582"
+
+  def initialize
+    @signatures = []
+  end
+
+  def count
+    @signatures.size
+  end
+
+  def skip(kind, mime_type, element, message)
+    @signatures << [kind, mime_type, canonical_element(element)].inspect
+    warn message
+  end
+
+  def verify!
+    return if count.zero?
+
+    digest = Digest::SHA256.hexdigest(@signatures.sort.join("\0"))
+    return if count == EXPECTED_COUNT && digest == EXPECTED_SHA256
+
+    raise ArgumentError,
+      "Unsupported magic rules changed: expected #{EXPECTED_COUNT} " \
+      "(sha256 #{EXPECTED_SHA256}), got #{count} (sha256 #{digest})"
+  end
+
+  private
+    def canonical_element(element)
+      attributes = element.attribute_nodes.sort_by(&:name).map { |attribute| [attribute.name, attribute.value] }
+      children = element.element_children.map { |child| canonical_element(child) }
+      [element.name, attributes, children]
+    end
 end
 
 class BinaryString
@@ -70,7 +200,7 @@ class BinaryString
   end
 
   def inspect
-    "b[#{@string.inspect}]"
+    "b[#{RubySource.string(@string)}]"
   end
 end
 
@@ -80,7 +210,12 @@ class RegexString
   end
 
   def inspect
-    TikaRegex.to_ruby_regexp(@pattern).inspect
+    regexp = TikaRegex.to_ruby_regexp(@pattern)
+    if regexp
+      "Regexp.new(#{regexp.source.b.dump}.b, #{regexp.options}).freeze"
+    else
+      "nil"
+    end
   end
 end
 
@@ -88,6 +223,29 @@ def str2int(s)
   return s.to_i(16) if s[0..1].downcase == '0x'
   return s.to_i(8) if s[0..0].downcase == '0'
   s.to_i(10)
+end
+
+ESCAPED_CHARACTERS = {
+  'a' => "\a",
+  'b' => "\b",
+  'e' => "\e",
+  'f' => "\f",
+  'n' => "\n",
+  'r' => "\r",
+  's' => " ",
+  't' => "\t",
+  'v' => "\v",
+}.freeze
+
+def decode_string_escape(escape)
+  case escape
+  when /\Ax([0-9a-f]{1,2})\z/i
+    $1.to_i(16).chr
+  when /\A0?([0-7]{1,3})\z/
+    $1.to_i(8).chr
+  else
+    ESCAPED_CHARACTERS.fetch(escape, escape)
+  end
 end
 
 def binary_strings(object)
@@ -112,39 +270,39 @@ WELL_KNOWN_REGEX_TYPES = %w(
   application/vnd.java.hprof.text
 )
 
-def get_matches(mime, parent)
+def get_matches(mime_type, parent, unsupported_rules)
   parent.elements.map {|match|
-    children = get_matches(mime, match)
+    children = get_matches(mime_type, match, unsupported_rules)
 
     type = match['type']
     value = match['value']
     offset = match['offset'] || '0'
-    offset = offset.split(':').map {|x| x.to_i }
+    offset = MimeData.offset(offset, mime_type)
 
     mask = match['mask']
 
     # We only support masks of whole bytes against a string type
     if mask && (!mask.match?(/\A0x(FF|00)*\z/) || type != 'string')
-      warn "#{mime['type']}: unsupported mask #{match.to_s}"
+      unsupported_rules.skip "mask", mime_type, match, "#{mime_type}: unsupported mask #{match.to_s}"
       next nil
     end
 
-    offset = offset.size == 2 ? offset[0]..offset[1] : offset[0]
     case type
       when 'unicodeLE', 'unicodeBE' # Unicode string types (UTF-16 Little/Big Endian)
         value.gsub!(/\A0x([0-9a-f]+)\z/i) { [$1].pack('H*') }
         encoding = type == 'unicodeLE' ? Encoding::UTF_16LE : Encoding::UTF_16BE
         value = value.encode(encoding).force_encoding(Encoding::BINARY)
     when 'regex'
-      unless WELL_KNOWN_REGEX_TYPES.include?(mime['type'].strip)
-        warn "#{mime['type']}: unsupported #{type} match: #{match.to_s}"
+      unless WELL_KNOWN_REGEX_TYPES.include?(mime_type)
+        unsupported_rules.skip "regex", mime_type, match,
+          "#{mime_type}: unsupported #{type} match: #{match.to_s}"
         next nil
       end
 
       value = RegexString.new(value)
     when 'string', 'stringignorecase'
       value.gsub!(/\A0x([0-9a-f]+)\z/i) { [$1].pack('H*') }
-      value.gsub!(/\\(x[\dA-Fa-f]{1,2}|0\d{1,3}|\d{1,3}|.)/) { eval("\"\\#{$1}\"") }
+      value.gsub!(/\\(x[\dA-Fa-f]{1,2}|0\d{1,3}|\d{1,3}|.)/) { decode_string_escape($1) }
 
       if mask
         segments = []
@@ -191,7 +349,8 @@ def get_matches(mime, parent)
     when nil
       nil
     else
-      warn "#{mime['type']}: unsupported #{type} match: #{match.to_s}"
+      unsupported_rules.skip "type", mime_type, match,
+        "#{mime_type}: unsupported #{type} match: #{match.to_s}"
       next nil
     end
 
@@ -199,10 +358,15 @@ def get_matches(mime, parent)
   }.compact
 end
 
-if ARGV.size == 0
-  puts "Usage: #{$0} path/to/data.xml"
-  exit 1
+options = {}
+option_parser = OptionParser.new do |parser|
+  parser.banner = "Usage: #{$0} [--output path/to/tables.rb] path/to/data.xml [...]"
+  parser.on("-o", "--output PATH", "Atomically write generated Ruby to PATH") do |path|
+    options[:output] = path
+  end
 end
+option_parser.parse!(ARGV)
+abort option_parser.to_s if ARGV.empty?
 
 TYPE_RENAMES = {
   "image/bmp;format=compressed" => "image/bmp",
@@ -211,20 +375,30 @@ TYPE_RENAMES = {
 extensions = {}
 types = {}
 magics = []
+unsupported_rules = UnsupportedRules.new
 
 ARGV.each do |path|
-  file = File.new(path)
-  doc = Nokogiri::XML(file)
+  doc = File.open(path, "rb") do |file|
+    Nokogiri::XML(file) { |config| config.strict.nonet }
+  end
+  unless doc.root&.name == "mime-info"
+    raise ArgumentError, "Expected mime-info root in #{path}"
+  end
 
   (doc/'mime-info/mime-type').each do |mime|
     comments = Hash[*(mime/'_comment').map {|comment| [comment['xml:lang'], comment.inner_text] }.flatten]
-    type = TYPE_RENAMES[mime['type']] || mime['type']
+    type = MimeData.type(mime['type'], path)
+    type = TYPE_RENAMES[type] || type
 
-    subclass = (mime/'sub-class-of').map{|x| x['type']}
-    exts = (mime/'glob').map{|x| x['pattern'] =~ /^\*\.([^\[\]]+)$/ ? $1.downcase : nil }.compact
+    subclass = (mime/'sub-class-of').map { |element| MimeData.type(element['type'], path) }
+    exts = (mime/'glob').map do |element|
+      if element['pattern'] =~ /^\*\.([^\[\]]+)$/
+        MimeData.extension($1, path)
+      end
+    end.compact
     (mime/'magic').each do |magic|
-      priority = (magic['priority'] || '50').to_i
-      matches = get_matches(mime, magic)
+      priority = MimeData.priority(magic['priority'] || '50', type)
+      matches = get_matches(type, magic, unsupported_rules)
       magics << [priority, type, matches]
     end
     if !exts.empty?
@@ -236,7 +410,9 @@ ARGV.each do |path|
   end
 end
 
-magics = magics.sort_by { |priority, type| [-priority, type] }
+magics = magics.each_with_index.sort_by do |(priority, type), source_index|
+  [ -priority, type, source_index ]
+end.map(&:first)
 
 common_types = [
   "image/jpeg",                                                                # .jpg
@@ -282,45 +458,76 @@ end
 
 magics = (common_magics.compact + magics).uniq
 
-puts "# frozen_string_literal: true"
-puts ""
-puts "# This file is auto-generated. Instead of editing this file, please"
-puts "# add MIMEs to data/custom.xml or lib/marcel/mime_type/definitions.rb."
-puts ""
-puts "module Marcel"
-puts "  # @private"
-puts "  # :nodoc:"
-puts "  EXTENSIONS = {"
-extensions.keys.sort.each do |key|
-  puts "    '#{key.strip}' => '#{extensions[key]}',"
+def emit_tables(output, extensions, types, magics)
+  output.puts "# frozen_string_literal: true"
+  output.puts ""
+  output.puts "# This file is auto-generated. Instead of editing this file, please"
+  output.puts "# add MIMEs to data/custom.xml or the definitions files under lib/marcel."
+  output.puts ""
+  output.puts "module Marcel"
+  output.puts "  # @private"
+  output.puts "  # :nodoc:"
+  output.puts "  EXTENSIONS = {"
+  extensions.keys.sort.each do |key|
+    output.puts "    #{RubySource.string(key.strip)} => #{RubySource.string(extensions[key])},"
+  end
+  output.puts "  }"
+  output.puts "  # @private"
+  output.puts "  # :nodoc:"
+  output.puts "  TYPE_EXTS = {"
+  types.keys.sort.each do |key|
+    exts = types[key][0]
+    comment = types[key][2]
+    comment = " # #{RubySource.comment(comment)}" if comment
+    output.puts "    #{RubySource.string(key.strip)} => #{RubySource.words(exts)},#{comment}"
+  end
+  output.puts "  }"
+  output.puts "  TYPE_PARENTS = {"
+  types.keys.sort.each do |key|
+    parents = types[key][1].sort
+    unless parents.empty?
+      output.puts "    #{RubySource.string(key.strip)} => #{RubySource.words(parents)},"
+    end
+  end
+  output.puts "  }"
+  output.puts "  b = Hash.new { |h, k| h[k] = k.b.freeze }"
+  output.puts "  # @private"
+  output.puts "  # :nodoc:"
+  output.puts "  MAGIC = ["
+  magics.each do |priority, type, matches|
+    next if matches.nil? || matches.empty?
+
+    output.puts "    [#{RubySource.string(type.strip)}, #{binary_strings(matches).inspect}],"
+  end
+  output.puts "  ]"
+  output.puts "end"
 end
-puts "  }"
-puts "  # @private"
-puts "  # :nodoc:"
-puts "  TYPE_EXTS = {"
-types.keys.sort.each do |key|
-  exts = types[key][0].join(' ')
-  comment = types[key][2]
-  comment = " # #{comment.tr("\n", " ")}" if comment
-  puts "    '#{key.strip}' => %w(#{exts}),#{comment}"
-end
-puts "  }"
-puts "  TYPE_PARENTS = {"
-types.keys.sort.each do |key|
-  parents = types[key][1].sort.join(' ')
-  unless parents.empty?
-    puts "    '#{key.strip}' => %w(#{parents}),"
+
+def write_tables(output_path, contents)
+  return $stdout.write(contents) unless output_path
+
+  destination = File.expand_path(output_path)
+  directory = File.dirname(destination)
+  mode = File.exist?(destination) ? File.stat(destination).mode & 0o777 : 0o644
+
+  Tempfile.create([File.basename(destination), ".tmp"], directory) do |temporary|
+    temporary.binmode
+    temporary.write(contents)
+    temporary.flush
+    temporary.fsync
+    temporary.close
+
+    syntax_output, status = Open3.capture2e(RbConfig.ruby, "-c", temporary.path)
+    raise "Generated table syntax is invalid:\n#{syntax_output}" unless status.success?
+
+    File.chmod(mode, temporary.path)
+    File.rename(temporary.path, destination)
   end
 end
-puts "  }"
-puts "  b = Hash.new { |h, k| h[k] = k.b.freeze }"
-puts "  # @private"
-puts "  # :nodoc:"
-puts "  MAGIC = ["
-magics.each do |priority, type, matches|
-  next if matches.nil? || matches.empty?
 
-  puts "    ['#{type.strip}', #{binary_strings(matches).inspect}],"
-end
-puts "  ]"
-puts "end"
+unsupported_rules.verify!
+
+buffer = StringIO.new
+emit_tables(buffer, extensions, types, magics)
+write_tables(options[:output], buffer.string)
+warn "Skipped #{unsupported_rules.count} unsupported magic rules" if unsupported_rules.count > 0

--- a/test/generate_tables_test.rb
+++ b/test/generate_tables_test.rb
@@ -1,0 +1,352 @@
+require "test_helper"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+class Marcel::GenerateTablesTest < Marcel::TestCase
+  test "serializes XML data as inert Ruby source" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/x-bzip2">
+          <magic>
+            <match type="regex" value="#{raise(&quot;regex interpolation executed&quot;)}" />
+          </magic>
+        </mime-type>
+        <mime-type type="application/x-generated">
+          <_comment>Generated comment&#10;raise "comment injection executed"</_comment>
+          <glob pattern="*.safe" />
+          <sub-class-of type="application/zip" />
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      tables_path = File.join(directory, "tables.rb")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+      assert status.success?, errors
+      assert_includes generated, "Regexp.new("
+      File.binwrite(tables_path, generated)
+
+      verification = "load ARGV.fetch(0); abort unless Marcel::EXTENSIONS.key?(ARGV.fetch(1))"
+      _output, errors, status = Open3.capture3(
+        RbConfig.ruby, "-e", verification, tables_path, "safe"
+      )
+      assert status.success?, errors
+    end
+  end
+
+  test "rejects code-shaped MIME fields" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/x-pwn&apos;]; raise(&quot;type interpolation executed&quot;); #">
+          <glob pattern="*.safe" />
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      refute status.success?
+      assert_empty generated
+      assert_includes errors, "Invalid MIME type"
+    end
+  end
+
+  test "rejects malformed XML instead of recovering it" do
+    xml = '<mime-info><mime-type type="text/plain"><glob pattern="*.txt" /></mime-info>'
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      refute status.success?
+      assert_empty generated
+      assert_includes errors, "Nokogiri::XML::SyntaxError"
+    end
+  end
+
+  test "normalizes surrounding MIME type whitespace" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/vnd.java.hprof ">
+          <glob pattern="*.hprof" />
+        </mime-type>
+        <mime-type type="application/x-example; version=1">
+          <glob pattern="*.example" />
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      tables_path = File.join(directory, "tables.rb")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+      assert status.success?, errors
+      File.binwrite(tables_path, generated)
+
+      verification = <<~'RUBY'
+        load ARGV.fetch(0)
+        abort unless Marcel::EXTENSIONS.fetch("hprof") == "application/vnd.java.hprof"
+        abort if Marcel::TYPE_EXTS.key?("application/vnd.java.hprof ")
+        abort unless Marcel::EXTENSIONS.fetch("example") == "application/x-example; version=1"
+      RUBY
+      _output, errors, status = Open3.capture3(RbConfig.ruby, "-e", verification, tables_path)
+      assert status.success?, errors
+    end
+  end
+
+  test "rejects control characters before normalizing MIME fields" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="&#xA;application/x-hidden">
+          <glob pattern="*.hidden" />
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      refute status.success?
+      assert_empty generated
+      assert_includes errors, "Invalid MIME type"
+    end
+  end
+
+  test "bounds offsets, ranges, and priorities before converting them" do
+    invalid_values = [
+      [ "offset", "65537", "Magic offset exceeds 65536" ],
+      [ "offset", "0:65536", "Magic range exceeds 65536 bytes" ],
+      [ "offset", "2:1", "Descending magic offset" ],
+      [ "offset", "1#{'0' * 100}", "Invalid magic offset" ],
+      [ "priority", "101", "Magic priority exceeds 100" ],
+      [ "priority", "1#{'0' * 100}", "Invalid magic priority" ],
+    ]
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      invalid_values.each_with_index do |(attribute, value, message), index|
+        magic_attribute = attribute == "priority" ? %( priority="#{value}") : ""
+        match_attribute = attribute == "offset" ? %( offset="#{value}") : ""
+        xml = <<~XML
+          <mime-info>
+            <mime-type type="application/x-bounded">
+              <magic#{magic_attribute}>
+                <match type="string" value="BOUND"#{match_attribute} />
+              </magic>
+            </mime-type>
+          </mime-info>
+        XML
+        xml_path = File.join(directory, "invalid-#{index}.xml")
+        File.binwrite(xml_path, xml)
+
+        generated, errors, status = Open3.capture3(
+          RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+        )
+
+        refute status.success?, "accepted #{attribute}=#{value.inspect}"
+        assert_empty generated
+        assert_includes errors, message
+      end
+    end
+  end
+
+  test "accepts the bounded offset range and priority limits" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/x-bounded">
+          <magic priority="100">
+            <match type="string" value="FIXED" offset="65536" />
+            <match type="string" value="RANGE" offset="1:65536" />
+          </magic>
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      assert status.success?, errors
+      assert_includes generated, "65536"
+      assert_includes generated, "1..65536"
+    end
+  end
+
+  test "uses source order to break equal magic priority ties" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/x-ordered">
+          <magic priority="50"><match type="string" value="FIRST" /></magic>
+          <magic priority="50"><match type="string" value="SECOND" /></magic>
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      assert status.success?, errors
+      assert_operator generated.index("FIRST"), :<, generated.index("SECOND")
+    end
+  end
+
+  test "pins the reviewed unsupported Tika rule set" do
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      tables_path = File.join(directory, "tables.rb")
+      _generated, errors, status = Open3.capture3(
+        RbConfig.ruby,
+        File.expand_path("../script/generate_tables.rb", __dir__),
+        "--output", tables_path,
+        File.expand_path("../data/tika.xml", __dir__),
+        File.expand_path("../data/custom.xml", __dir__)
+      )
+
+      assert status.success?, errors
+      warning_lines = errors.lines
+      assert_equal "Skipped 58 unsupported magic rules\n", warning_lines.pop
+      assert_equal 112, warning_lines.size
+      assert File.exist?(tables_path)
+    end
+  end
+
+  test "verifies the committed Tika source against its pinned checksum" do
+    _output, errors, status = Open3.capture3(
+      RbConfig.ruby,
+      File.expand_path("../script/download_tika_data.rb", __dir__),
+      "--verify", File.expand_path("../data/tika.xml", __dir__)
+    )
+
+    assert status.success?, errors
+  end
+
+  test "rejects altered committed Tika source data" do
+    tika_data = File.binread(File.expand_path("../data/tika.xml", __dir__))
+    alterations = [
+      tika_data.sub("<!-- Downloaded from ", "<!-- Copied from "),
+      tika_data.sub('pattern="*.ez"', 'pattern="*.unexpected-ez"'),
+    ]
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      alterations.each_with_index do |altered_data, index|
+        refute_equal tika_data, altered_data
+        xml_path = File.join(directory, "altered-#{index}.xml")
+        File.binwrite(xml_path, altered_data)
+
+        output, errors, status = Open3.capture3(
+          RbConfig.ruby,
+          File.expand_path("../script/download_tika_data.rb", __dir__),
+          "--verify", xml_path
+        )
+
+        refute status.success?
+        assert_empty output
+        assert_includes errors, "Unexpected Tika"
+      end
+    end
+  end
+
+  test "rejects an unreviewed unsupported rule without emitting output" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/x-unsupported">
+          <magic>
+            <match type="regex" value="UNREVIEWED" />
+          </magic>
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      refute status.success?
+      assert_empty generated
+      assert_includes errors, "Unsupported magic rules changed"
+      assert_includes errors, "got 1"
+    end
+  end
+
+  test "buffers stdout until every rule has serialized" do
+    xml = <<-'XML'
+      <mime-info>
+        <mime-type type="application/x-bzip2">
+          <magic>
+            <match type="regex" value="[" />
+          </magic>
+        </mime-type>
+      </mime-info>
+    XML
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      File.binwrite(xml_path, xml)
+
+      generated, errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__), xml_path
+      )
+
+      refute status.success?
+      assert_empty generated
+      assert_match(/premature end of char-class|unterminated character class/, errors)
+    end
+  end
+
+  test "preserves an existing output file when direct generation fails" do
+    malformed_xml = '<mime-info><mime-type type="text/plain"></mime-info>'
+
+    Dir.mktmpdir("marcel-generator-test") do |directory|
+      xml_path = File.join(directory, "input.xml")
+      tables_path = File.join(directory, "tables.rb")
+      File.binwrite(xml_path, malformed_xml)
+      File.binwrite(tables_path, "existing artifact\n")
+
+      generated, _errors, status = Open3.capture3(
+        RbConfig.ruby, File.expand_path("../script/generate_tables.rb", __dir__),
+        "--output", tables_path, xml_path
+      )
+
+      refute status.success?
+      assert_empty generated
+      assert_equal "existing artifact\n", File.binread(tables_path)
+    end
+  end
+
+end

--- a/test/magic_test.rb
+++ b/test/magic_test.rb
@@ -27,6 +27,11 @@ class Marcel::MimeType::MagicTest < Marcel::TestCase
     refute Marcel::Magic.child?('text/plain', 'text/csv')
   end
 
+  test "X bitmap resolves its C source alias to a canonical text parent" do
+    assert Marcel::Magic.child?('image/x-xbitmap', 'text/x-csrc')
+    assert Marcel::Magic.new('image/x-xbitmap').text?
+  end
+
   test "no Ruby 3.4 frozen string warnings with StringIO" do
     # Ruby 3.4 warns about code that will break when frozen string literals become default
     # This test ensures marcel handles StringIO with frozen strings correctly


### PR DESCRIPTION
Table generation reads Apache Tika XML and emits Ruby source. This change makes that path repeatable and stops before replacing the tables when input or output is invalid.

- Pin the Tika source by commit and checksum.
- Verify both downloaded and committed Tika data before generation.
- Validate MIME fields, offsets, ranges, priorities, and unsupported rules.
- Serialize source values as data.
- Write syntax-checked output atomically and verify table parity in the default test task.

It also normalizes the existing HPROF type and the X bitmap parent.

Local validation: `bundle exec rake`.
