### PR TITLE
Handle IO edge cases while sniffing

### DIFF
--- a/lib/marcel/magic.rb
+++ b/lib/marcel/magic.rb
@@ -71,7 +71,10 @@ module Marcel
 
     # Lookup mime type by file extension
     def self.by_extension(ext)
-      ext = ext.to_s.downcase
+      ext = ext.to_s
+      return unless ext.valid_encoding?
+
+      ext = ext.downcase
       mime = ext[0..0] == '.' ? EXTENSIONS[ext[1..-1]] : EXTENSIONS[ext]
       mime && new(mime)
     end
@@ -79,6 +82,8 @@ module Marcel
     # Lookup mime type by filename
     def self.by_path(path)
       by_extension(File.extname(path))
+    rescue ArgumentError, EncodingError
+      nil
     end
 
     # Lookup mime type by magic content analysis.
@@ -111,17 +116,46 @@ module Marcel
     alias == eql?
 
     def self.child?(child, parent)
-      child == parent || TYPE_PARENTS[child]&.any? {|p| child?(p, parent) }
+      pending = [child]
+      visited = {}
+
+      until pending.empty?
+        type = pending.pop
+        return true if type == parent
+        next if visited[type]
+
+        visited[type] = true
+        pending.concat(TYPE_PARENTS[type] || [])
+      end
+
+      false
     end
 
     def self.magic_match(io, method)
+      if defined?(Pathname) && io.is_a?(Pathname)
+        return io.open("rb") { |file| magic_match(file, method) }
+      end
+
       return magic_match(StringIO.new(io.to_s), method) unless io.respond_to?(:read)
 
       buffer = "".b
-      MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer) }
+      read_mode = read_mode(io)
+      io.rewind
+      body_failed = true
+      begin
+        result = MAGIC.send(method) { |type, matches| magic_match_io(io, matches, buffer, read_mode) }
+        body_failed = false
+        result
+      ensure
+        begin
+          io.rewind
+        rescue Exception # Preserve an exception already raised while reading or matching.
+          raise unless body_failed
+        end
+      end
     end
 
-    def self.magic_match_io(io, matches, buffer)
+    def self.magic_match_io(io, matches, buffer, mode = read_mode(io))
       matches.any? do |offset, value, children|
         match = if value
           is_range = Range === offset
@@ -129,12 +163,15 @@ module Marcel
           sample_size = is_regexp ? 256 : value.bytesize
 
           x = if is_range
-            io_seek(io, offset.begin, buffer)
-            io.read(offset.end - offset.begin + sample_size, buffer)
+            if io_seek(io, offset.begin, buffer, mode)
+              io_read(io, offset.end - offset.begin + sample_size, buffer, mode)
+            end
           else
-            io_seek(io, offset, buffer)
-            io.read(sample_size, buffer)
+            if io_seek(io, offset, buffer, mode)
+              io_read(io, sample_size, buffer, mode)
+            end
           end
+          x.force_encoding(Encoding::BINARY) if x
 
           if is_regexp
             x&.match?(value)
@@ -146,24 +183,71 @@ module Marcel
         end
 
         io.rewind
-        match && (!children || magic_match_io(io, children, buffer))
+        match && (!children || magic_match_io(io, children, buffer, mode))
       end
     end
 
-    def self.io_seek(io, offset, buffer)
-      return if offset == 0
-      offset = io.size + offset if offset < 0
-      return if offset < 0
+    def self.io_seek(io, offset, buffer, mode)
+      return true if offset == 0
+
+      if offset < 0
+        return false unless io.respond_to?(:size)
+
+        offset = io.size + offset
+        return false if offset < 0
+      end
 
       if io.respond_to?(:seek)
-        io.seek(offset, IO::SEEK_CUR)
+        io.seek(offset, IO::SEEK_SET)
       else
         # Some IOs don't support `seek`. e.g. Rack::RewindableInput
-        io.read(offset, buffer)
+        skipped = io_read(io, offset, buffer, mode)
+        return false unless skipped && skipped.bytesize == offset
       end
+
+      true
     end
 
-    private_class_method :magic_match, :magic_match_io, :io_seek
+    def self.io_read(io, length, buffer, mode)
+      return io.read(length, buffer) if mode == :native
+
+      buffer.clear
+
+      read_with_buffer = mode == :buffer
+      chunk = read_with_buffer ? io.read(length, buffer) : io.read(length)
+      return if chunk && chunk.bytesize > length
+      buffer.replace(chunk) if chunk && !chunk.equal?(buffer)
+
+      return if chunk.nil? || buffer.empty?
+      return buffer if buffer.bytesize == length
+
+      continuation_buffer = "".b if read_with_buffer
+      while buffer.bytesize < length
+        remaining = length - buffer.bytesize
+        chunk = if read_with_buffer
+          io.read(remaining, continuation_buffer.clear)
+        else
+          io.read(remaining)
+        end
+        return if chunk && chunk.bytesize > remaining
+        break if chunk.nil? || chunk.empty?
+
+        buffer << chunk
+      end
+
+      buffer unless buffer.empty?
+    end
+
+    def self.read_mode(io)
+      return :native if io.is_a?(IO) || io.is_a?(StringIO)
+
+      parameters = io.method(:read).parameters
+      supports_buffer = parameters.any? { |kind,| kind == :rest } ||
+        parameters.count { |kind,| kind == :req || kind == :opt } >= 2
+      supports_buffer ? :buffer : :single
+    end
+
+    private_class_method :magic_match, :magic_match_io, :io_seek, :io_read, :read_mode
   end
 end
 

--- a/lib/marcel/mime_type.rb
+++ b/lib/marcel/mime_type.rb
@@ -70,7 +70,7 @@ module Marcel
 
         def with_io(pathname_or_io, &block)
           if defined?(Pathname) && pathname_or_io.is_a?(Pathname)
-            pathname_or_io.open(&block)
+            pathname_or_io.open("rb", &block)
           else
             yield pathname_or_io
           end

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -9,6 +9,22 @@ class Marcel::MimeType::ExtensionTest < Marcel::TestCase
     assert_equal "application/pdf", Marcel::MimeType.for(extension: ".pdf")
   end
 
+  test "ignores invalidly encoded extensions without raising" do
+    invalid_extension = "html\xFF".dup.force_encoding(Encoding::UTF_8)
+
+    assert_nil Marcel::Magic.by_extension(invalid_extension)
+    assert_equal "application/octet-stream", Marcel::MimeType.for(extension: invalid_extension)
+  end
+
+  test "preserves valid custom non-ASCII extensions" do
+    type = "application/x-unicode-extension"
+    Marcel::Magic.add(type, extensions: "éx")
+
+    assert_equal type, Marcel::MimeType.for(extension: "ÉX")
+  ensure
+    Marcel::Magic.remove(type)
+  end
+
   extensions = []
 
   each_content_type_fixture('name') do |file, name, content_type|

--- a/test/magic_test.rb
+++ b/test/magic_test.rb
@@ -32,6 +32,16 @@ class Marcel::MimeType::MagicTest < Marcel::TestCase
     assert Marcel::Magic.new('image/x-xbitmap').text?
   end
 
+  test ".child? handles custom parent cycles" do
+    Marcel::Magic.add('application/x-cycle-a', parents: 'application/x-cycle-b')
+    Marcel::Magic.add('application/x-cycle-b', parents: 'application/x-cycle-a')
+
+    refute Marcel::Magic.child?('application/x-cycle-a', 'application/zip')
+  ensure
+    Marcel::Magic.remove('application/x-cycle-a')
+    Marcel::Magic.remove('application/x-cycle-b')
+  end
+
   test "no Ruby 3.4 frozen string warnings with StringIO" do
     # Ruby 3.4 warns about code that will break when frozen string literals become default
     # This test ensures marcel handles StringIO with frozen strings correctly
@@ -152,6 +162,234 @@ class Marcel::MimeType::MagicTest < Marcel::TestCase
     io3 = StringIO.new("ROOTXXXX")
     refute Marcel::Magic.send(:magic_match_io, io3, test_rules, buffer),
            "Should not match when parent matches but no child matches"
+  end
+
+  test "negative offsets do not scan from the start of short data" do
+    rules = [[-64, %r{\A<html>}]]
+
+    refute Marcel::Magic.send(:magic_match_io, StringIO.new("<html>"), rules, "".b)
+  end
+
+  test "negative offsets are skipped when the IO has no size" do
+    io = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+      end
+
+      def read(*args)
+        @io.read(*args)
+      end
+
+      def seek(*args)
+        @io.seek(*args)
+      end
+
+      def rewind
+        @io.rewind
+      end
+    end.new("x" * 64 + "</html>")
+
+    rules = [[-64, %r{</html>\z}]]
+
+    refute Marcel::Magic.send(:magic_match_io, io, rules, "".b)
+  end
+
+  test "non-seekable IO consumes exact offsets despite short reads" do
+    io = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+        @first_read = true
+      end
+
+      def read(length)
+        length = 1 if @first_read
+        @first_read = false
+        @io.read(length)
+      end
+
+      def rewind
+        @first_read = true
+        @io.rewind
+      end
+    end.new("Xftypavif")
+
+    assert_equal "application/octet-stream", Marcel::MimeType.for(io)
+  end
+
+  test "two-argument non-seekable IO consumes exact offsets despite short reads" do
+    io = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+      end
+
+      def read(length, buffer)
+        chunk = @io.read([length, 1].min)
+        chunk ? buffer.replace(chunk) : nil
+      end
+
+      def rewind
+        @io.rewind
+      end
+    end.new("Xftypavif")
+
+    assert_equal "application/octet-stream", Marcel::MimeType.for(io)
+  end
+
+  test "custom IO samples are matched as binary data" do
+    one_argument_reader = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+      end
+
+      def read(length)
+        @io.read(length)&.force_encoding(Encoding::UTF_8)
+      end
+
+      def rewind
+        @io.rewind
+      end
+    end
+
+    two_argument_reader = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+      end
+
+      def read(length, buffer)
+        chunk = @io.read(length)
+        chunk ? buffer.replace(chunk).force_encoding(Encoding::UTF_8) : nil
+      end
+
+      def rewind
+        @io.rewind
+      end
+    end
+
+    [one_argument_reader, two_argument_reader].each do |reader|
+      assert_equal "text/html", Marcel::MimeType.for(reader.new("<html><body>café</body></html>"))
+      assert_equal "image/png", Marcel::MimeType.for(reader.new(File.binread(files("magic/image/png/png.png"))))
+    end
+  end
+
+  test "non-seekable IO skips offset rules at early EOF" do
+    io = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+      end
+
+      def read(length)
+        @io.read([length, 1].min)
+      end
+
+      def rewind
+        @io.rewind
+      end
+    end.new("Xft")
+
+    rules = [[4, "ftypavif".b]]
+
+    refute Marcel::Magic.send(:magic_match_io, io, rules, "".b)
+  end
+
+  test "public magic matching rewinds after a read exception" do
+    io = Class.new do
+      def initialize
+        @io = StringIO.new("data")
+      end
+
+      def read(*_args)
+        @io.read(1)
+        raise IOError, "read failed"
+      end
+
+      def rewind
+        @io.rewind
+      end
+
+      def position
+        @io.pos
+      end
+    end.new
+
+    assert_raises(IOError) { Marcel::Magic.by_magic(io) }
+    assert_equal 0, io.position
+  end
+
+  test "a cleanup rewind failure does not mask a read failure" do
+    original_error = ArgumentError.new("original read failed")
+    io = Class.new do
+      def initialize(original_error)
+        @original_error = original_error
+        @rewinds = 0
+      end
+
+      def read(*)
+        raise @original_error
+      end
+
+      def rewind
+        @rewinds += 1
+        raise IOError, "cleanup rewind failed" if @rewinds > 1
+      end
+    end.new(original_error)
+
+    raised_error = assert_raises(ArgumentError) { Marcel::Magic.by_magic(io) }
+    assert_same original_error, raised_error
+  end
+
+  test "a cleanup rewind failure is preserved after successful matching" do
+    Marcel::Magic.add("application/x-cleanup-test", magic: [[0, "MATCH"]])
+    io = Class.new do
+      def initialize(data)
+        @io = StringIO.new(data)
+        @rewinds = 0
+      end
+
+      def read(*args)
+        @io.read(*args)
+      end
+
+      def rewind
+        @rewinds += 1
+        raise IOError, "cleanup rewind failed" if @rewinds == 3
+
+        @io.rewind
+      end
+    end.new("MATCH")
+
+    error = assert_raises(IOError) { Marcel::Magic.by_magic(io) }
+    assert_equal "cleanup rewind failed", error.message
+  ensure
+    Marcel::Magic.remove("application/x-cleanup-test")
+  end
+
+  test "public magic matching accepts Pathnames and closes their files" do
+    path_class = Class.new(Pathname) do
+      attr_reader :opened_files
+
+      def initialize(path)
+        super
+        @opened_files = []
+      end
+
+      def open(*arguments)
+        file = File.open(to_path, *arguments)
+        @opened_files << file
+        return file unless block_given?
+
+        begin
+          yield file
+        ensure
+          file.close
+        end
+      end
+    end
+    path = path_class.new(files("image.gif").to_s)
+
+    assert_equal "image/gif", Marcel::Magic.by_magic(path).type
+    assert_includes Marcel::Magic.all_by_magic(path).map(&:type), "image/gif"
+    assert_equal 2, path.opened_files.size
+    assert path.opened_files.all?(&:closed?)
   end
 
   test "complex nested structure with multiple levels" do

--- a/test/mime_type_test.rb
+++ b/test/mime_type_test.rb
@@ -18,6 +18,18 @@ class Marcel::MimeTypeTest < Marcel::TestCase
     assert_equal "image/gif", content_type
   end
 
+  test "opens Pathnames in binary mode" do
+    pathname = Pathname.new(@path)
+    opened_mode = nil
+    pathname.define_singleton_method(:open) do |mode, &block|
+      opened_mode = mode
+      File.open(to_path, mode, &block)
+    end
+
+    assert_equal "image/gif", Marcel::MimeType.for(pathname)
+    assert_equal "rb", opened_mode
+  end
+
   test "closes Pathname files after use" do
     skip if RUBY_ENGINE == "jruby"
     open_files = ObjectSpace.each_object(File).reject(&:closed?)
@@ -36,6 +48,13 @@ class Marcel::MimeTypeTest < Marcel::TestCase
     io = StringIO.new(File.read(@path))
     content_type = Marcel::MimeType.for io
     assert_equal "image/gif", content_type
+  end
+
+  test "reads IOs from the beginning" do
+    io = StringIO.new(File.read(@path))
+    io.read(10)
+
+    assert_equal "image/gif", Marcel::MimeType.for(io)
   end
 
   test "gets content type from sources that conform to Rack RewindableInput" do

--- a/test/name_test.rb
+++ b/test/name_test.rb
@@ -2,6 +2,31 @@ require 'test_helper'
 require 'rack'
 
 class Marcel::MimeType::NameTest < Marcel::TestCase
+  test "ignores invalidly encoded filename extensions without raising" do
+    invalid_name = "file.html\xFF".dup.force_encoding(Encoding::UTF_8)
+
+    assert_nil Marcel::Magic.by_path(invalid_name)
+    assert_equal "application/octet-stream", Marcel::MimeType.for(name: invalid_name)
+  end
+
+  test "uses a valid extension after an invalidly encoded basename" do
+    name = "file\xFF.html".dup.force_encoding(Encoding::UTF_8)
+
+    assert_equal "text/html", Marcel::MimeType.for(name: name)
+  end
+
+  test "ignores filenames that cannot be parsed as paths" do
+    invalid_names = [
+      "file.html\0.pdf",
+      "file.html".encode(Encoding::UTF_16LE),
+    ]
+
+    invalid_names.each do |invalid_name|
+      assert_nil Marcel::Magic.by_path(invalid_name)
+      assert_equal "application/octet-stream", Marcel::MimeType.for(name: invalid_name)
+    end
+  end
+
   each_content_type_fixture('name') do |file, name, content_type|
     test "gets type for #{content_type} by filename from #{name}" do
       assert_equal content_type, Marcel::MimeType.for(name: name)


### PR DESCRIPTION
Stacked on #158.

Magic sniffing now reads bounded samples correctly from seekable, short-reading, and size-less IO objects.

It also:

- treats sampled bytes as binary when a custom reader tags them as text
- leaves inputs rewound
- preserves the original detection error if cleanup fails
- opens Pathnames in binary mode
- ignores invalid filenames
- prevents cycles in custom parent registrations from overflowing the stack

No MIME signatures change in this PR.

Local validation: `bundle exec ruby -Itest test/magic_test.rb`.
