### PR TITLE
Validate declared MIME types

### DIFF
--- a/lib/marcel/mime_type.rb
+++ b/lib/marcel/mime_type.rb
@@ -3,6 +3,10 @@
 module Marcel
   class MimeType
     BINARY = "application/octet-stream"
+    MAX_DECLARED_TYPE_BYTES = 8 * 1024
+    TOKEN = "[!#$%&'*+\\-.^_`|~0-9A-Za-z]+"
+    QUOTED_STRING = '"(?:[\t\x20\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\\\[\t\x20-\x7E\x80-\xFF])*"'
+    MEDIA_TYPE = %r{\A(#{TOKEN}/#{TOKEN})(?:[ \t]*;[ \t]*#{TOKEN}=(?:#{TOKEN}|#{QUOTED_STRING}))*(?:[ \t]*;[ \t]*)?\z}n
 
     class << self
       def extend(type, extensions: [], parents: [], magic: nil)
@@ -23,7 +27,13 @@ module Marcel
       #
       # The most appropriate type is determined by the following:
       # * type declared by binary magic number data
-      # * type declared by the first of file name, file extension, or declared MIME type
+      # * valid declared MIME type, unless it is application/octet-stream
+      # * type inferred from the file name or extension
+      #
+      # A later candidate is used only if it is more specific than the type already found.
+      #
+      # The result is a best-effort label, not validation that the file is safe or conforms to
+      # the returned type. Treat +name+ and +declared_type+ as hints from their respective sources.
       #
       # If no type can be determined, then +application/octet-stream+ is returned.
       def for(pathname_or_io = nil, name: nil, extension: nil, declared_type: nil)
@@ -77,10 +87,15 @@ module Marcel
         end
 
         def parse_media_type(content_type)
-          if content_type
-            result = content_type.downcase.split(/[;,\s]/, 2).first
-            result if result && result.index("/")
-          end
+          return unless content_type
+          return if content_type.bytesize > MAX_DECLARED_TYPE_BYTES
+
+          content_type = content_type.dup.force_encoding(Encoding::BINARY)
+          content_type.sub!(/\A[ \t\r\n]+/n, "")
+          content_type.sub!(/[ \t\r\n]+\z/n, "")
+
+          media_type = MEDIA_TYPE.match(content_type)
+          media_type[1].downcase.force_encoding(Encoding::UTF_8) if media_type
         end
 
         # For some document types (notably Microsoft Office) we recognise the main content

--- a/test/declared_type_test.rb
+++ b/test/declared_type_test.rb
@@ -19,4 +19,89 @@ class Marcel::MimeType::DeclaredTypeTest < Marcel::TestCase
   test "ignores charset declarations" do
     assert_equal "text/html", Marcel::MimeType.for(declared_type: "text/html; charset=utf-8")
   end
+
+  test "tolerates a single trailing semicolon" do
+    assert_equal "image/jpeg", Marcel::MimeType.for(declared_type: "image/jpeg;")
+    assert_equal "text/html", Marcel::MimeType.for(declared_type: "text/html; charset=utf-8; ")
+  end
+
+  test "normalizes case and surrounding HTTP whitespace" do
+    assert_equal "text/html", Marcel::MimeType.for(declared_type: " \tTEXT/HTML\r\n")
+    assert_equal "text/html", Marcel::MimeType.for(name: "file.txt", declared_type: " text/html")
+  end
+
+  test "accepts valid media type tokens" do
+    assert_equal "application/vnd.example+json", Marcel::MimeType.for(declared_type: "APPLICATION/VND.EXAMPLE+JSON")
+  end
+
+  test "allows commas in quoted parameters" do
+    assert_equal "text/html", Marcel::MimeType.for(declared_type: 'text/html; example="one,two"')
+    assert_equal "text/html", Marcel::MimeType.for(declared_type: 'text/html; example="one\",two"')
+  end
+
+  test "ignores malformed media types" do
+    malformed_types = [
+      "/html",
+      "text/",
+      "text/ html",
+      "text/html garbage",
+      "text/html\0garbage",
+      "text/html/extra",
+      "text/{html",
+      "t\u00EBxt/html",
+      "\vtext/html",
+      "\ftext/html",
+      "text/html;;charset=utf-8",
+      "text/html; ; charset=utf-8",
+      "text/html; example=foo\", image/png\"",
+      "text/html; example=\"unterminated",
+      "text/html; example=foo\0bar",
+    ]
+
+    malformed_types.each do |declared_type|
+      assert_equal "application/octet-stream", Marcel::MimeType.for(declared_type: declared_type),
+        "Expected #{declared_type.inspect} to be ignored"
+      assert_equal "text/plain", Marcel::MimeType.for(name: "file.txt", declared_type: declared_type),
+        "Expected #{declared_type.inspect} to fall back to the filename"
+    end
+  end
+
+  test "ignores comma-separated media type lists" do
+    ["text/html, image/png", "image/png, text/html", "invalid, text/html"].each do |declared_type|
+      assert_equal "application/octet-stream", Marcel::MimeType.for(declared_type: declared_type),
+        "Expected #{declared_type.inspect} to be ignored"
+      assert_equal "text/plain", Marcel::MimeType.for(name: "file.txt", declared_type: declared_type),
+        "Expected #{declared_type.inspect} to fall back to the filename"
+    end
+  end
+
+  test "normalizes binary type before treating it as undeclared" do
+    assert_equal "text/plain", Marcel::MimeType.for(
+      name: "file.txt", declared_type: " \tAPPLICATION/OCTET-STREAM ; example=value\r\n"
+    )
+  end
+
+  test "ignores invalidly encoded declared types without raising" do
+    invalid_type = "text/html\xFF".dup.force_encoding(Encoding::UTF_8)
+
+    assert_equal "application/octet-stream", Marcel::MimeType.for(declared_type: invalid_type)
+    assert_equal "text/plain", Marcel::MimeType.for(name: "file.txt", declared_type: invalid_type)
+  end
+
+  test "returns well-formed unknown declared types as UTF-8 labels" do
+    result = Marcel::MimeType.for(name: "file.html", declared_type: "APPLICATION/X-EVIL")
+
+    assert_equal "application/x-evil", result
+    assert_equal Encoding::UTF_8, result.encoding
+  end
+
+  test "bounds declared type metadata" do
+    prefix = "application/"
+    maximum = prefix + ("a" * (Marcel::MimeType::MAX_DECLARED_TYPE_BYTES - prefix.bytesize))
+    oversized = maximum + "a"
+
+    assert_equal maximum, Marcel::MimeType.for(declared_type: maximum)
+    assert_equal "application/octet-stream", Marcel::MimeType.for(declared_type: oversized)
+    assert_equal "text/plain", Marcel::MimeType.for(name: "file.txt", declared_type: oversized)
+  end
 end


### PR DESCRIPTION
Stacked on #159.

Declared types now accept one well-formed media type with optional parameters. Malformed values, comma-separated lists, invalid encodings, and values larger than 8 KiB are ignored so detection can continue with the other inputs.

A single trailing semicolon remains accepted for compatibility. A valid but unregistered media type is still returned by design.

Local validation: `bundle exec ruby -Itest test/declared_type_test.rb`.
