### PR TITLE
Run CI with locked dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: bundler
+    directory: /gemfiles/runtime
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,86 @@
 name: CI
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      BUNDLE_FROZEN: "true"
+      BUNDLE_GEMFILE: ${{ matrix.gemfile || 'Gemfile' }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         experimental: [false]
         include:
+        - ruby: "2.7"
+          experimental: false
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
+        - ruby: "3.0"
+          experimental: false
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
+        - ruby: "3.1"
+          experimental: false
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
         - ruby: head
           experimental: true
+          bundler: default
+          gemfile: gemfiles/runtime/Gemfile
+          skip_cache: true
+          task: test:runtime
         - ruby: jruby
           experimental: true
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
         - ruby: jruby-head
           experimental: true
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
         - ruby: truffleruby
           experimental: true
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
         - ruby: truffleruby-head
           experimental: true
+          gemfile: gemfiles/runtime/Gemfile
+          task: test:runtime
 
     name: ${{ matrix.ruby }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler: ${{ matrix.bundler || 'Gemfile.lock' }}
+          bundler-cache: ${{ !matrix.skip_cache }}
+
+      - name: Install Ruby head dependencies
+        if: matrix.ruby == 'head'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundler_version="$(ruby -rbundler -e 'print Bundler::VERSION')"
+          [[ "$bundler_version" =~ ^[0-9]+([.][0-9]+)*([.]dev)?$ ]]
+          printf 'BUNDLER_VERSION=%s\n' "$bundler_version" >> "$GITHUB_ENV"
+          BUNDLER_VERSION="$bundler_version" bundle install
 
       - name: Run tests
-        run: bundle exec rake
+        env:
+          RAKE_TASK: ${{ matrix.task || 'default' }}
+        run: bundle exec rake "$RAKE_TASK"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-Gemfile.lock
 *.gem
 .byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ if RUBY_VERSION >= "2.7"
   gem "debug", platform: :mri
 end
 
+gem "nokogiri", ">= 1.19.4"
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,106 @@
+PATH
+  remote: .
+  specs:
+    marcel (1.2.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    erb (6.0.7)
+    io-console (0.9.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    logger (1.7.0)
+    minitest (5.27.0)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
+      racc (~> 1.4)
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    racc (1.8.1)
+    rack (3.2.7)
+    rake (13.4.2)
+    rbs (4.1.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    reline (0.7.0)
+      io-console (~> 0.5)
+    tsort (0.2.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  bundler (>= 1.7)
+  debug
+  irb
+  marcel!
+  minitest (~> 5.11)
+  nokogiri (>= 1.19.4)
+  rack (>= 2)
+  rake (>= 13.0)
+
+CHECKSUMS
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  marcel (1.2.1)
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+
+BUNDLED WITH
+  4.0.6

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,11 @@ Rake::TestTask.new :test do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
+Rake::TestTask.new "test:runtime" do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/**/*_test.rb'].exclude('test/generate_tables_test.rb')
+end
+
 namespace :test do
   task tables: [ :tables, :test ]
   task update: [ :update, :test ]

--- a/gemfiles/runtime/Gemfile
+++ b/gemfiles/runtime/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+# Ruby 2.7 uses Bundler 2.4, whose lock format does not enforce checksums.
+gemspec path: "../.."

--- a/gemfiles/runtime/Gemfile.lock
+++ b/gemfiles/runtime/Gemfile.lock
@@ -1,0 +1,25 @@
+PATH
+  remote: ../..
+  specs:
+    marcel (1.2.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.26.1)
+    rack (3.2.7)
+    rake (13.4.2)
+
+PLATFORMS
+  arm64-darwin-27
+  ruby
+
+DEPENDENCIES
+  bundler (>= 1.7)
+  marcel!
+  minitest (~> 5.11)
+  rack (>= 2)
+  rake (>= 13.0)
+
+BUNDLED WITH
+   2.4.22

--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '>= 13.0'
   spec.add_development_dependency 'rack', '>= 2'
-  spec.add_development_dependency 'nokogiri', '>= 1.9.1'
-
   spec.metadata["changelog_uri"] = 'https://github.com/rails/marcel/releases'
 end

--- a/test/package_test.rb
+++ b/test/package_test.rb
@@ -65,6 +65,13 @@ class Marcel::PackageTest < Marcel::TestCase
     assert_empty specification.runtime_dependencies
   end
 
+  test "locks runtime dependencies with the Bundler supported by Ruby 2.7" do
+    lock = File.binread(File.join(PROJECT_ROOT, "gemfiles/runtime/Gemfile.lock"))
+    assert_equal "https://rubygems.org/", lock[/^GEM\n  remote: (.+)$/, 1]
+    refute_match(/^CHECKSUMS$/, lock)
+    assert_match(/\nBUNDLED WITH\n   2\.4\.22\n?\z/, lock)
+  end
+
   test "requires the oldest Ruby exercised by CI" do
     assert specification.required_ruby_version.satisfied_by?(Gem::Version.new("2.7.0"))
     refute specification.required_ruby_version.satisfied_by?(Gem::Version.new("2.6.10"))


### PR DESCRIPTION
Stacked on #162.

CI now uses frozen dependency sets. The modern development lock carries checksums. Ruby 2.7 uses a frozen Bundler 2.4 lock; that lock format does not support checksums.

- Run the full suite on Ruby 3.2 through 4.0.
- Run runtime-only tests on Ruby 2.7 through 3.1 and alternative Ruby implementations.
- Pin actions and runners, use read-only permissions, and do not persist checkout credentials.
- Check for dependency updates weekly.

Nokogiri remains a development-only tool.

Local validation: full Ruby 4 and Ruby 2.7 suites, Actionlint, and pedantic Zizmor.
