### PR TITLE
Pin the devcontainer base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Marcel",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "ghcr.io/rails/devcontainer/images/ruby:3.4.6",
+	"image": "ghcr.io/rails/devcontainer/images/ruby:3.4.6@sha256:4906355f9b25276ccd9cf29f690b2af7d3862dc5b683a045aed6fb3d5ad3a4d6",
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	}


### PR DESCRIPTION
The GitHub CLI feature is already locked to a digest in #154. This companion change pins the Ruby base image to its current digest as well, so moving tags do not change the development environment unexpectedly.

This does not affect the gem or its runtime dependencies.
