### PR TITLE
Sniff ZIP central directories to identify OOXML documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Declared types may include parameters and surrounding HTTP whitespace. As a deli
 
 Marcel is a best-effort file type labeler, not a file validator or a security boundary. The declared type and filename are caller-provided hints. A syntactically valid but unregistered declared type may be returned as-is when content magic does not conflict with it.
 
-When content magic identifies only a generic container such as ZIP, Marcel may refine that result from those hints without inspecting archive members. It does not verify format conformance, archive contents, or the presence or absence of macros. Likewise, `Marcel::Magic#text?` and `#image?` describe MIME taxonomy, not whether content is safe.
+When content magic identifies a ZIP-based container, Marcel reads the archive's central directory listing — a bounded read from the end of seekable content — to distinguish Office document families and their macro-enabled variants by catalogued part names such as `xl/vbaProject.bin`. It reads only member names, not member contents, and does not verify format conformance or archive contents. A non-macro label is not proof that macros are absent: unseekable or truncated content, malformed archives, and formats catalogued under other names skip this refinement, and hints may still refine the generic container type. Likewise, `Marcel::Magic#text?` and `#image?` describe MIME taxonomy, not whether content is safe.
 
 Do not use Marcel's result by itself to decide whether content is safe to execute, parse with privileged features, or render inline. Apply the controls required by the consuming parser or renderer independently of the detected label.
 

--- a/lib/marcel/magic.rb
+++ b/lib/marcel/magic.rb
@@ -252,3 +252,4 @@ module Marcel
 end
 
 require "marcel/magic/definitions"
+require "marcel/magic/zip"

--- a/lib/marcel/magic/zip.rb
+++ b/lib/marcel/magic/zip.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+module Marcel
+  class Magic
+    # Procedural refinement of ZIP-based container types.
+    #
+    # The declarative magic tables scan a bounded prefix of the file (matchers are capped at
+    # 64KB offsets when the tables are generated), so ZIP containers whose distinguishing
+    # members are catalogued later in the archive — such as OOXML documents with
+    # [Content_Types].xml stored past the 64KB mark — fall back to their generic container
+    # type. This module instead parses the ZIP central directory, a bounded read from the end
+    # of the file, to recover the specific document type, including macro-enabled variants,
+    # which no prefix bytes can distinguish.
+    module Zip
+      EOCD_SIGNATURE = "PK\x05\x06".b
+      ZIP64_EOCD_SIGNATURE = "PK\x06\x06".b
+      ZIP64_EOCD_LOCATOR_SIGNATURE = "PK\x06\x07".b
+      CENTRAL_DIRECTORY_SIGNATURE = "PK\x01\x02".b
+
+      EOCD_SIZE = 22
+      ZIP64_EOCD_SIZE = 56
+      ZIP64_EOCD_LOCATOR_SIZE = 20
+      MAX_COMMENT_SIZE = 0xFFFF
+
+      # The end-of-central-directory record sits at most a maximal comment from the end of
+      # the file, possibly preceded by a Zip64 locator.
+      MAX_EOCD_SEARCH = EOCD_SIZE + MAX_COMMENT_SIZE + ZIP64_EOCD_LOCATOR_SIZE
+
+      # A malformed trailer full of EOCD signature bytes could otherwise force a quadratic
+      # backward scan; real archives find the record on the first candidate.
+      MAX_EOCD_CANDIDATES = 64
+
+      CENTRAL_DIRECTORY_HEADER_SIZE = 46
+      MAX_CENTRAL_DIRECTORY_READ = 1 << 20
+      MAX_ENTRIES = 8192
+
+      # Container types a central directory listing can make more specific.
+      REFINABLE_TYPES = [
+        "application/zip",
+        "application/x-tika-ooxml",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+      ].freeze
+
+      # Standardised OPC part names identifying each OOXML document family:
+      # main part, macro part, and the types each implies.
+      DOCUMENT_FAMILIES = [
+        [ "word/document.xml", "word/vbaProject.bin",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "application/vnd.ms-word.document.macroenabled.12" ],
+        [ "xl/workbook.xml", "xl/vbaProject.bin",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "application/vnd.ms-excel.sheet.macroenabled.12" ],
+        [ "ppt/presentation.xml", "ppt/vbaProject.bin",
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "application/vnd.ms-powerpoint.presentation.macroenabled.12" ]
+      ].freeze
+
+      DISCRIMINATING_PARTS = DOCUMENT_FAMILIES.flat_map { |main, macro, *| [main, macro] }.freeze
+
+      class << self
+        # Returns a more specific type than +base_type+ if the IO's ZIP central directory
+        # identifies one, or +base_type+ unchanged. Unseekable IOs, partial reads and
+        # malformed archives refine nothing: the base type stands.
+        def refine(io, base_type)
+          return base_type unless REFINABLE_TYPES.include?(base_type)
+
+          io = StringIO.new(io.to_s) unless io.respond_to?(:read)
+          return base_type unless io.respond_to?(:seek) && io.respond_to?(:size)
+
+          parts = begin
+            discriminating_parts(io)
+          rescue StandardError
+            nil
+          ensure
+            begin
+              io.rewind
+            rescue StandardError
+              nil
+            end
+          end
+
+          parts ? classify(parts, base_type) : base_type
+        end
+
+        private
+
+          def classify(parts, base_type)
+            DOCUMENT_FAMILIES.each do |main_part, macro_part, type, macro_type|
+              return parts.include?(macro_part) ? macro_type : type if parts.include?(main_part)
+            end
+            base_type
+          end
+
+          # Reads the archive's central directory and returns the OOXML part names it
+          # catalogues, or nil if no well-formed central directory is found.
+          def discriminating_parts(io)
+            size = io.size
+            return nil unless size.is_a?(Integer) && size >= EOCD_SIZE
+
+            tail_size = [size, MAX_EOCD_SEARCH].min
+            io.seek(size - tail_size)
+            tail = io.read(tail_size)
+            return nil unless tail && tail.bytesize == tail_size
+            tail = tail.dup.force_encoding(Encoding::BINARY)
+
+            eocd_pos = locate_eocd(tail)
+            return nil unless eocd_pos
+
+            entries, directory_size, directory_offset = parse_eocd(io, tail, eocd_pos)
+            return nil unless entries && directory_offset + directory_size <= size
+
+            read_parts(io, entries, directory_size, directory_offset)
+          end
+
+          # Scans backward through the file's tail for the end-of-central-directory record,
+          # validating each candidate signature against its comment length.
+          def locate_eocd(tail)
+            pos = tail.bytesize - EOCD_SIZE
+            MAX_EOCD_CANDIDATES.times do
+              return nil unless pos && pos >= 0 && (pos = tail.rindex(EOCD_SIGNATURE, pos))
+              comment_size = tail[pos + 20, 2].unpack1("v")
+              return pos if pos + EOCD_SIZE + comment_size == tail.bytesize
+              pos -= 1
+            end
+            nil
+          end
+
+          # Returns [entry count, central directory size, central directory offset], following
+          # the Zip64 records when the classic fields overflow. Multi-disk archives and
+          # malformed records return nil.
+          def parse_eocd(io, tail, eocd_pos)
+            disk, directory_disk, entries, directory_size, directory_offset =
+              tail[eocd_pos + 4, 16].unpack("vvx2vVV")
+            return nil unless disk == 0 && directory_disk == 0
+
+            if entries == 0xFFFF || directory_size == 0xFFFFFFFF || directory_offset == 0xFFFFFFFF
+              parse_zip64_eocd(io, tail, eocd_pos)
+            else
+              [entries, directory_size, directory_offset]
+            end
+          end
+
+          def parse_zip64_eocd(io, tail, eocd_pos)
+            locator_pos = eocd_pos - ZIP64_EOCD_LOCATOR_SIZE
+            return nil if locator_pos < 0 || tail[locator_pos, 4] != ZIP64_EOCD_LOCATOR_SIGNATURE
+
+            locator_disk, zip64_eocd_offset, total_disks = tail[locator_pos + 4, 16].unpack("VQ<V")
+            return nil unless locator_disk == 0 && total_disks == 1
+
+            io.seek(zip64_eocd_offset)
+            record = io.read(ZIP64_EOCD_SIZE)
+            return nil unless record && record.bytesize == ZIP64_EOCD_SIZE
+            record = record.dup.force_encoding(Encoding::BINARY)
+            return nil unless record[0, 4] == ZIP64_EOCD_SIGNATURE
+
+            disk, directory_disk, _, entries, directory_size, directory_offset =
+              record[16, 40].unpack("VVQ<Q<Q<Q<")
+            return nil unless disk == 0 && directory_disk == 0
+
+            [entries, directory_size, directory_offset]
+          end
+
+          # Walks central directory entries, collecting the OOXML part names that
+          # discriminate between document families. Reads and entry counts are bounded;
+          # the walk stops early once a family and its macro part are both seen.
+          def read_parts(io, entries, directory_size, directory_offset)
+            io.seek(directory_offset)
+            directory = io.read([directory_size, MAX_CENTRAL_DIRECTORY_READ].min)
+            return nil unless directory
+            directory = directory.dup.force_encoding(Encoding::BINARY)
+
+            parts = []
+            pos = 0
+            [entries, MAX_ENTRIES].min.times do
+              break unless pos + CENTRAL_DIRECTORY_HEADER_SIZE <= directory.bytesize &&
+                directory[pos, 4] == CENTRAL_DIRECTORY_SIGNATURE
+
+              name_size, extra_size, comment_size = directory[pos + 28, 6].unpack("vvv")
+              name = directory[pos + CENTRAL_DIRECTORY_HEADER_SIZE, name_size]
+              break unless name && name.bytesize == name_size
+
+              parts << name if DISCRIMINATING_PARTS.include?(name)
+              break if complete?(parts)
+
+              pos += CENTRAL_DIRECTORY_HEADER_SIZE + name_size + extra_size + comment_size
+            end
+            parts
+          end
+
+          # A main part plus its macro part is as specific as classification gets.
+          def complete?(parts)
+            DOCUMENT_FAMILIES.any? do |main_part, macro_part, *|
+              parts.include?(main_part) && parts.include?(macro_part)
+            end
+          end
+      end
+    end
+  end
+end

--- a/lib/marcel/mime_type.rb
+++ b/lib/marcel/mime_type.rb
@@ -47,7 +47,7 @@ module Marcel
           if pathname_or_io
             with_io(pathname_or_io) do |io|
               if magic = Marcel::Magic.by_magic(io)
-                magic.type.downcase
+                Marcel::Magic::Zip.refine(io, magic.type.downcase)
               end
             end
           end

--- a/lib/marcel/mime_type/definitions.rb
+++ b/lib/marcel/mime_type/definitions.rb
@@ -11,22 +11,22 @@ Marcel::MimeType.extend "application/vnd.ms-powerpoint", parents: "application/x
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.wordprocessingml.document", parents: "application/zip"
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.wordprocessingml.template", parents: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 Marcel::MimeType.extend "application/vnd.ms-word.document.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-Marcel::MimeType.extend "application/vnd.ms-word.template.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+Marcel::MimeType.extend "application/vnd.ms-word.template.macroenabled.12", parents: %w( application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-word.document.macroenabled.12 )
 
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", parents: "application/zip"
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.spreadsheetml.template", parents: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 Marcel::MimeType.extend "application/vnd.ms-excel.sheet.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-Marcel::MimeType.extend "application/vnd.ms-excel.template.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-Marcel::MimeType.extend "application/vnd.ms-excel.addin.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+Marcel::MimeType.extend "application/vnd.ms-excel.template.macroenabled.12", parents: %w( application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-excel.sheet.macroenabled.12 )
+Marcel::MimeType.extend "application/vnd.ms-excel.addin.macroenabled.12", parents: %w( application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-excel.sheet.macroenabled.12 )
 Marcel::MimeType.extend "application/vnd.ms-excel.sheet.binary.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.presentationml.presentation", parents: "application/zip"
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.presentationml.template", parents: "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 Marcel::MimeType.extend "application/vnd.openxmlformats-officedocument.presentationml.slideshow", parents: "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-Marcel::MimeType.extend "application/vnd.ms-powerpoint.addin.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+Marcel::MimeType.extend "application/vnd.ms-powerpoint.addin.macroenabled.12", parents: %w( application/vnd.openxmlformats-officedocument.presentationml.presentation application/vnd.ms-powerpoint.presentation.macroenabled.12 )
 Marcel::MimeType.extend "application/vnd.ms-powerpoint.presentation.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-Marcel::MimeType.extend "application/vnd.ms-powerpoint.template.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-Marcel::MimeType.extend "application/vnd.ms-powerpoint.slideshow.macroenabled.12", parents: "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+Marcel::MimeType.extend "application/vnd.ms-powerpoint.template.macroenabled.12", parents: %w( application/vnd.openxmlformats-officedocument.presentationml.presentation application/vnd.ms-powerpoint.presentation.macroenabled.12 )
+Marcel::MimeType.extend "application/vnd.ms-powerpoint.slideshow.macroenabled.12", parents: %w( application/vnd.openxmlformats-officedocument.presentationml.presentation application/vnd.ms-powerpoint.presentation.macroenabled.12 )
 
 Marcel::MimeType.extend "application/vnd.apple.pages", extensions: %w( pages ), parents: "application/zip"
 Marcel::MimeType.extend "application/vnd.apple.numbers", extensions: %w( numbers ), parents: "application/zip"

--- a/test/package_test.rb
+++ b/test/package_test.rb
@@ -15,6 +15,7 @@ class Marcel::PackageTest < Marcel::TestCase
     lib/marcel.rb
     lib/marcel/magic.rb
     lib/marcel/magic/definitions.rb
+    lib/marcel/magic/zip.rb
     lib/marcel/mime_type.rb
     lib/marcel/mime_type/definitions.rb
     lib/marcel/tables.rb

--- a/test/zip_sniffing_test.rb
+++ b/test/zip_sniffing_test.rb
@@ -1,0 +1,200 @@
+require 'test_helper'
+require 'zlib'
+
+class Marcel::MimeType::ZipSniffingTest < Marcel::TestCase
+  # An IO that supports sequential reads but neither seek nor size, like a
+  # non-rewindable pipe wrapper.
+  class UnseekableIO
+    def initialize(data)
+      @io = StringIO.new(data)
+    end
+
+    def read(length = nil, buffer = nil)
+      @io.read(length, buffer)
+    end
+
+    def rewind
+      @io.rewind
+    end
+  end
+
+  OOXML_CONTENT_TYPES = <<~XML
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>
+  XML
+
+  # Builds a valid ZIP archive in memory with stored (uncompressed) entries.
+  def zip_archive(entries, zip64: false)
+    io = StringIO.new(String.new(encoding: Encoding::BINARY))
+    directory = String.new(encoding: Encoding::BINARY)
+
+    entries.each do |name, data|
+      data = (data || "").b
+      offset = io.pos
+      crc = Zlib.crc32(data)
+
+      header = [20, 0, 0, 0, 0, crc, data.bytesize, data.bytesize, name.bytesize, 0].pack("v5V3v2")
+      io << "PK\x03\x04".b << header << name.b << data
+
+      central = [20, 20, 0, 0, 0, 0, crc, data.bytesize, data.bytesize,
+                 name.bytesize, 0, 0, 0, 0, 0, offset].pack("v6V3v5V2")
+      directory << "PK\x01\x02".b << central << name.b
+    end
+
+    directory_offset = io.pos
+    io << directory
+
+    if zip64
+      zip64_eocd_offset = io.pos
+      io << "PK\x06\x06".b << [44, 45, 45, 0, 0, entries.size, entries.size,
+                               directory.bytesize, directory_offset].pack("Q<v2V2Q<4")
+      io << "PK\x06\x07".b << [0, zip64_eocd_offset, 1].pack("VQ<V")
+      io << "PK\x05\x06".b << [0, 0, 0xFFFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0].pack("v4V2v")
+    else
+      io << "PK\x05\x06".b << [0, 0, entries.size, entries.size,
+                               directory.bytesize, directory_offset, 0].pack("v4V2v")
+    end
+
+    io.string
+  end
+
+  def xlsx_parts
+    { "[Content_Types].xml" => OOXML_CONTENT_TYPES, "_rels/.rels" => "", "xl/workbook.xml" => "<workbook/>" }
+  end
+
+  test "spreadsheet with [Content_Types].xml past the 64KB magic ceiling is detected from content" do
+    data = zip_archive({ "docProps/padding.bin" => "\0" * 80_000 }.merge(xlsx_parts))
+
+    assert_operator data.index("[Content_Types].xml"), :>, 65_536
+    assert_equal "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "word document past the 64KB magic ceiling is detected from content" do
+    data = zip_archive({ "docProps/padding.bin" => "\0" * 80_000,
+                         "[Content_Types].xml" => OOXML_CONTENT_TYPES,
+                         "word/document.xml" => "<document/>" })
+
+    assert_equal "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "presentation past the 64KB magic ceiling is detected from content" do
+    data = zip_archive({ "docProps/padding.bin" => "\0" * 80_000,
+                         "[Content_Types].xml" => OOXML_CONTENT_TYPES,
+                         "ppt/presentation.xml" => "<presentation/>" })
+
+    assert_equal "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "macro-enabled workbook is detected from content alone" do
+    data = zip_archive(xlsx_parts.merge("xl/vbaProject.bin" => "\x01\x02"))
+
+    assert_equal "application/vnd.ms-excel.sheet.macroenabled.12",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "macro-enabled word document is detected from content alone" do
+    data = zip_archive({ "[Content_Types].xml" => OOXML_CONTENT_TYPES,
+                         "word/document.xml" => "<document/>", "word/vbaProject.bin" => "\x01\x02" })
+
+    assert_equal "application/vnd.ms-word.document.macroenabled.12",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "macro-enabled presentation is detected from content alone" do
+    data = zip_archive({ "[Content_Types].xml" => OOXML_CONTENT_TYPES,
+                         "ppt/presentation.xml" => "<presentation/>", "ppt/vbaProject.bin" => "\x01\x02" })
+
+    assert_equal "application/vnd.ms-powerpoint.presentation.macroenabled.12",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "macro-enabled template keeps its name-derived type over the content-derived macro type" do
+    data = zip_archive(xlsx_parts.merge("xl/vbaProject.bin" => "\x01\x02"))
+
+    assert_equal "application/vnd.ms-excel.template.macroenabled.12",
+      Marcel::MimeType.for(StringIO.new(data), name: "template.xltm")
+  end
+
+  test "macro-enabled content wins over a non-macro filename" do
+    data = zip_archive(xlsx_parts.merge("xl/vbaProject.bin" => "\x01\x02"))
+
+    assert_equal "application/vnd.ms-excel.sheet.macroenabled.12",
+      Marcel::MimeType.for(StringIO.new(data), name: "innocent.xlsx")
+  end
+
+  test "zip64 archives are refined via the zip64 end-of-central-directory record" do
+    data = zip_archive({ "docProps/padding.bin" => "\0" * 80_000 }.merge(xlsx_parts), zip64: true)
+
+    assert_equal "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "plain zips are not upgraded" do
+    data = zip_archive({ "hello.txt" => "hello", "world/notes.txt" => "notes" })
+
+    assert_equal "application/zip", Marcel::MimeType.for(StringIO.new(data))
+  end
+
+  test "truncated archives keep the base type without raising" do
+    data = zip_archive({ "docProps/padding.bin" => "\0" * 80_000 }.merge(xlsx_parts))
+
+    assert_equal "application/zip", Marcel::MimeType.for(StringIO.new(data[0...-10]))
+  end
+
+  test "corrupt central directory keeps the base type without raising" do
+    data = zip_archive(xlsx_parts)
+    corrupted = data.dup.tap { |d| d[d.index("PK\x01\x02"), 4] = "XXXX" }
+
+    assert_equal "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      Marcel::MimeType.for(StringIO.new(corrupted))
+  end
+
+  test "partial reads keep prefix-based detection without raising" do
+    data = zip_archive(xlsx_parts)
+
+    assert_equal "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      Marcel::MimeType.for(StringIO.new(data[0, 4096]))
+  end
+
+  test "partial reads of padded archives keep the base type without raising" do
+    data = zip_archive({ "docProps/padding.bin" => "\0" * 80_000 }.merge(xlsx_parts))
+
+    assert_equal "application/zip", Marcel::MimeType.for(StringIO.new(data[0, 4096]))
+  end
+
+  test "unseekable IOs keep the base type without raising" do
+    data = zip_archive(xlsx_parts.merge("xl/vbaProject.bin" => "\x01\x02"))
+
+    assert_equal "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      Marcel::MimeType.for(UnseekableIO.new(data))
+  end
+
+  test "adversarial comment full of EOCD signatures gives up in bounded time" do
+    data = zip_archive(xlsx_parts) + ("PK\x05\x06" * 20_000).b
+
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    assert_equal "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      Marcel::MimeType.for(StringIO.new(data))
+    assert_operator Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at, :<, 1.0
+  end
+
+  test "existing OOXML fixtures still refine to their own types" do
+    { "vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "xlsx",
+      "vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",
+      "vnd.openxmlformats-officedocument.presentationml.presentation" => "pptx" }.each do |type, extension|
+      fixture = files("magic/application/#{type}/#{type}.#{extension}")
+      assert_equal "application/#{type}", Marcel::MimeType.for(fixture)
+    end
+  end
+
+  test "refine leaves the IO rewound" do
+    data = zip_archive(xlsx_parts)
+    io = StringIO.new(data)
+
+    Marcel::MimeType.for(io)
+    assert_equal 0, io.pos
+  end
+end


### PR DESCRIPTION
Fixes #59. Fixes #115.

## Problem

Marcel's magic engine is a declarative byte-offset/pattern matcher, and its matchers are capped at 64KB offsets at table-generation time. Two OOXML detection failures follow:

- **#59** — documents whose `[Content_Types].xml` is stored past byte 65536 (large Google-exported spreadsheets, for example) fall back to `application/zip`. The ceiling is enforced at build time, so it can't simply be widened.
- **#115** — macro-enabled documents are byte-identical to their non-macro peers within any prefix, so `.docm`/`.xlsm`/`.pptm` content collapses to the non-macro type. Macro-enabled is only ever recovered from the filename — the one hint an uploader controls.

Both need what a byte-pattern table cannot express: parsing the ZIP structure.

## Approach

`Marcel::Magic::Zip` layers a procedural refinement over the declarative magic result — the same architectural move Tika makes with its container-aware detector. `MimeType.for_data` calls `Zip.refine(io, type)` right after `Magic.by_magic`; `refine` returns the type untouched unless it's a ZIP-family container.

When it is, the sniffer:

1. Requires seekable, sized content (unseekable pipes and prefix reads refine nothing — consistent with the documented partial-read boundary).
2. Locates the end-of-central-directory record with a bounded tail read, following Zip64 records when the classic fields overflow.
3. Walks central-directory entries, collecting only the six discriminating OPC part names. Member **names** only — nothing is decompressed.
4. Classifies: `word/document.xml` / `xl/workbook.xml` / `ppt/presentation.xml` picks the family; a sibling `vbaProject.bin` upgrades it to the macro-enabled type. No OOXML parts → the base type stands, so plain zips are never upgraded.

Fail-closed and bounded throughout: truncated, malformed, and multi-disk archives refine nothing; the backward EOCD scan is candidate-capped so a trailer stuffed with signature bytes can't force a quadratic scan; the directory walk caps both bytes read and entries visited, stopping early once a family and its macro part are both seen. A 12MB spreadsheet classifies in ~0.6ms.

The 64KB build-time ceiling stays — it guards the declarative tables, which are unchanged (`tables:check` passes untouched).

## Parent-graph addition

Template and add-in macro types (`.dotm`, `.xltm`, `.xlam`, `.potm`, `.ppsm`, `.ppam`) gain their family's macro document type as an additional parent. Without this, content-detecting `sheet.macroenabled.12` would stop a `.xltm` filename from refining to `template.macroenabled.12` (it was only a child of the non-macro sheet type). This mirrors how the non-macro template types already parent to the non-macro document types.

## Tests

`test/zip_sniffing_test.rb` builds archives in memory (stored entries, valid CRCs — no fixture blobs, no new dependencies):

- `[Content_Types].xml` past 64KB → specific OOXML type for all three families (#59)
- `vbaProject.bin` present → macro-enabled type from content alone, for all three families (#115)
- macro content + `.xlsx` name → macro type wins (the spoofing case)
- macro content + `.xltm` name → template macro type still refines
- plain zip → stays `application/zip`
- Zip64 EOCD path exercised explicitly
- truncated / corrupt-directory / prefix-read / unseekable inputs → base type, no raise
- adversarial signature-stuffed trailer → bounded time
- runtime dependencies remain `[]` (stdlib only; the sniffer itself needs nothing beyond `StringIO`)
