### PR TITLE
Require Ruby 3.3, the oldest non-EOL Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
         experimental: [false]
+        gemfile: [Gemfile]
         include:
-        - ruby: "2.7"
-          experimental: false
-          gemfile: gemfiles/runtime/Gemfile
-          task: test:runtime
-        - ruby: "3.0"
-          experimental: false
-          gemfile: gemfiles/runtime/Gemfile
-          task: test:runtime
-        - ruby: "3.1"
+        - ruby: "3.3"
+          label: 3.3 runtime
           experimental: false
           gemfile: gemfiles/runtime/Gemfile
           task: test:runtime
@@ -56,7 +50,7 @@ jobs:
           gemfile: gemfiles/runtime/Gemfile
           task: test:runtime
 
-    name: ${{ matrix.ruby }}
+    name: ${{ matrix.label || matrix.ruby }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source "https://rubygems.org"
 
-if RUBY_VERSION >= "2.7"
-  gem "irb"
-  gem "debug", platform: :mri
-end
+gem "irb"
+gem "debug", platform: :mri
 
 gem "nokogiri", ">= 1.19.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    drb (2.2.3)
     erb (6.0.7)
     io-console (0.9.2)
     irb (1.18.0)
@@ -17,7 +18,9 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     logger (1.7.0)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.4-aarch64-linux-musl)
@@ -70,19 +73,20 @@ DEPENDENCIES
   debug
   irb
   marcel!
-  minitest (~> 5.11)
+  minitest (~> 6.0)
   nokogiri (>= 1.19.4)
   rack (>= 2)
   rake (>= 13.0)
 
 CHECKSUMS
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   marcel (1.2.1)
-  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
   nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
   nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca

--- a/gemfiles/runtime/Gemfile
+++ b/gemfiles/runtime/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
-# Ruby 2.7 uses Bundler 2.4, whose lock format does not enforce checksums.
 gemspec path: "../.."

--- a/gemfiles/runtime/Gemfile.lock
+++ b/gemfiles/runtime/Gemfile.lock
@@ -6,20 +6,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.26.1)
+    drb (2.2.3)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    prism (1.9.0)
     rack (3.2.7)
     rake (13.4.2)
 
 PLATFORMS
-  arm64-darwin-27
+  arm64-darwin-23
   ruby
 
 DEPENDENCIES
   bundler (>= 1.7)
   marcel!
-  minitest (~> 5.11)
+  minitest (~> 6.0)
   rack (>= 2)
   rake (>= 13.0)
 
+CHECKSUMS
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  marcel (1.2.1)
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+
 BUNDLED WITH
-   2.4.22
+  4.0.6

--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.3'
 
-  spec.add_development_dependency 'minitest', '~> 5.11'
+  spec.add_development_dependency 'minitest', '~> 6.0'
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '>= 13.0'
   spec.add_development_dependency 'rack', '>= 2'

--- a/test/package_test.rb
+++ b/test/package_test.rb
@@ -65,16 +65,18 @@ class Marcel::PackageTest < Marcel::TestCase
     assert_empty specification.runtime_dependencies
   end
 
-  test "locks runtime dependencies with the Bundler supported by Ruby 2.7" do
+  test "locks runtime dependencies with checksums using the same Bundler as the main lock" do
     lock = File.binread(File.join(PROJECT_ROOT, "gemfiles/runtime/Gemfile.lock"))
+    main_lock = File.binread(File.join(PROJECT_ROOT, "Gemfile.lock"))
+
     assert_equal "https://rubygems.org/", lock[/^GEM\n  remote: (.+)$/, 1]
-    refute_match(/^CHECKSUMS$/, lock)
-    assert_match(/\nBUNDLED WITH\n   2\.4\.22\n?\z/, lock)
+    assert_match(/^CHECKSUMS$/, lock)
+    assert_equal main_lock[/\nBUNDLED WITH\n\s+(\S+)/, 1], lock[/\nBUNDLED WITH\n\s+(\S+)/, 1]
   end
 
   test "requires the oldest Ruby exercised by CI" do
-    assert specification.required_ruby_version.satisfied_by?(Gem::Version.new("2.7.0"))
-    refute specification.required_ruby_version.satisfied_by?(Gem::Version.new("2.6.10"))
+    assert specification.required_ruby_version.satisfied_by?(Gem::Version.new("3.3.0"))
+    refute specification.required_ruby_version.satisfied_by?(Gem::Version.new("3.2.9"))
   end
 
   test "loads package metadata outside the project directory" do


### PR DESCRIPTION
Marcel's Ruby 2.7 floor pinned development dependencies to versions old enough to install there — most recently blocking the minitest 6 bump (#167). This adopts a supported-Ruby policy instead: **require the oldest non-EOL Ruby series**, currently 3.3 (supported until March 2027; 3.2 reached EOL 2026-03-31).

Nobody on an older Ruby breaks: Bundler resolves `required_ruby_version`, so apps on Ruby ≤ 3.2 — including Rails 8.x apps still on 3.2 — simply stay on the current Marcel release rather than picking up this line.

## Changes

- `required_ruby_version` → `>= 3.3`; minitest dev dependency → `~> 6.0` (the change the old floor was blocking); both lockfiles re-resolved.
- `Gemfile` drops its `RUBY_VERSION >= "2.7"` guard around irb/debug.
- `gemfiles/runtime/Gemfile.lock` was deliberately written by Bundler **2.4.22 without checksums** because Ruby 2.7 could go no newer. It's now re-locked with the same Bundler as the main lock and **enforces checksums**, and the package test asserts the two locks share a toolchain instead of pinning the 2.4 format — a strict hardening gain.
- CI matrix trims to 3.3 / 3.4 / 4.0 (+ head, JRuby, TruffleRuby as before). The dropped 2.7/3.0/3.1 legs were the only **non-experimental** jobs exercising the runtime gemfile, so a `3.3 runtime` leg replaces them. (`gemfile` joins the base matrix keys so the include adds a job instead of silently merging into the existing 3.3 leg.)
- Package test's floor guard updated: satisfied by 3.3.0, refuted for 3.2.x.

## Verification

- Main suite (Bundler 4.0.6, minitest 6.0.6): 527 runs, 0 failures; `tables:check` clean.
- Runtime gemfile under `BUNDLE_FROZEN=true`: 512 runs, 0 failures.
- Frozen install of the main lock passes, matching CI's `BUNDLE_FROZEN` mode.
