### PR TITLE
Marcel 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    marcel (1.2.1)
+    marcel (2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -85,7 +85,7 @@ CHECKSUMS
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  marcel (1.2.1)
+  marcel (2.0.0)
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
   nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af

--- a/gemfiles/runtime/Gemfile.lock
+++ b/gemfiles/runtime/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    marcel (1.2.1)
+    marcel (2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +27,7 @@ DEPENDENCIES
 
 CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  marcel (1.2.1)
+  marcel (2.0.0)
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7

--- a/lib/marcel/version.rb
+++ b/lib/marcel/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Marcel
-  VERSION = "1.2.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Version bump plus regenerated lockfile pins (CI runs frozen). The release notes below are the draft GitHub Release body — the gem's changelog_uri points at Releases, so this is the changelog. Review it here in context.

---

Marcel 2.0.0 modernizes the toolchain, hardens the release pipeline, and teaches the content sniffer several new families of formats. It is a major release because it drops old Rubies and changes the canonical type returned for some inputs — details below so you can scan for the ones that affect you.

## Breaking changes

- **Ruby 3.3 or newer is required** (was 2.3). (#170)
- **Canonical type changes** — the same bytes or filename may now return a different (more standard) type:
  - Aliased types now resolve to their canonical form on output (#171): `audio/x-aac` → `audio/aac`, `audio/x-flac` → `audio/flac`, `audio/vnd.wave` → `audio/x-wav`, `text/x-yaml` → `application/yaml`, `application/x-debian-package` → `application/vnd.debian.binary-package`, `application/x-xliff+xml` → `application/xliff+xml`. Lookups by any alias still work.
  - `image/bmp;format=compressed` is now plain `image/bmp` (#148).
  - `.cr2` files are `image/x-canon-cr2` instead of `image/x-raw-canon` (#172).
  - OpenXPS (`.oxps`) is split from XPS (#171).
  - The XML/HTML detection work below can relabel documents that previously fell back to `application/xml`, `text/html`, or `application/octet-stream`.

## Security & hardening

A review of the detection pipeline landed as a series of PRs (#157–#164):

- MIME data is validated before table generation, and the generated tables are checked in CI (#157, `rake tables:check`).
- HTML and XHTML magic matches only bounded opening-tag patterns instead of unanchored scans (#158).
- IO edge cases — partial reads, unseekable and unrewindable IOs, non-string input — are handled explicitly while sniffing (#159).
- Declared MIME types are validated rather than trusted (#160).
- Marcel's detection boundary — what sniffing does and does not promise — is documented in the README (#161).
- CI runs with locked dependencies (#163), and the release workflow builds and publishes the same verified gem artifact with sha256 recorded and sigstore attestation (#164), with the gem's contents verified by script (#162, #173).

## New detection

- OOXML documents (`.docx`/`.xlsx`/`.pptx` and their macro-enabled variants) are identified from the ZIP central directory, regardless of which application produced them (#169).
- XML vocabularies are identified by their root element, the way Apache Tika does: RSS, Atom, KML, Apple property lists, XSLT, ONIX, iWork flat XML, Office 2003 XML, and friends (#173 and #175, fixing #48).
- Canon CR2 raw images (#172).
- RAR archives (#155, @tristan-f-r) and Google Sheets shortcuts (#156, @tristan-f-r).
- AVIF image sequences (`avis` brand) (#151, @mm12) and audio-only `.m4a` files (#147).
- HTML detection also checks the end of the document for closing tags (#146).

## Performance

- The common-type fast path is restored with subtype-aware ordering, so common formats like JPEG are identified in ~25 IO reads instead of hundreds, without preempting subtype matchers (#172, #174).
- Sniffing uses `IO#seek` where possible instead of reading and discarding, including for regexp magic (#144, #145).

## Upgrading

Most applications need no changes beyond Ruby ≥ 3.3. If you compare Marcel's output against stored MIME types, re-check the canonical type changes above — lookups by the old aliases still resolve, but Marcel now returns the canonical name.