### PR TITLE
Marcel 2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    marcel (2.0.0)
+    marcel (2.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -85,7 +85,7 @@ CHECKSUMS
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  marcel (2.0.0)
+  marcel (2.1.0)
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
   nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af

--- a/gemfiles/runtime/Gemfile.lock
+++ b/gemfiles/runtime/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    marcel (2.0.0)
+    marcel (2.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +27,7 @@ DEPENDENCIES
 
 CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  marcel (2.0.0)
+  marcel (2.1.0)
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7

--- a/lib/marcel/version.rb
+++ b/lib/marcel/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Marcel
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Version bump for the Tika 4.0.0 data refresh (#177), classified there as minor-shaped:

* **Updated MIME definitions to Apache Tika 4.0.0.**
* **Added Android binary XML (`application/vnd.android.axml`) detection.**
* **Improved `timestamped-data` DER detection** — definite-length encodings now detected — **and stopped misidentifying sibling CMS content types** (`1.2.840.113549.1.9.16.1.*`) as timestamped-data.

No API, Ruby requirement, canonical type, alias, or extension changes.